### PR TITLE
fix(hooks): performance + reliability overhaul (v3.1.1)

### DIFF
--- a/.claude/hooks/action-report-tracker.sh
+++ b/.claude/hooks/action-report-tracker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # action-report-tracker.sh - Hook for automatic action report generation
 # Hook: PostToolUse (Task tool)
 # VERSION: 2.93.0

--- a/.claude/hooks/anti-rationalization-gate.sh
+++ b/.claude/hooks/anti-rationalization-gate.sh
@@ -35,14 +35,14 @@ INPUT=$(head -c 100000)
 
 # --- Guard: jq required, fail-open otherwise ---
 if ! command -v jq >/dev/null 2>&1; then
-  echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
   exit 0
 fi
 
 # --- Infinite-loop guard: honor stop_hook_active ---
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
-  echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
   exit 0
 fi
 
@@ -64,7 +64,7 @@ if [[ -f "$STATE_FILE" ]]; then
 fi
 if [[ "$BLOCK_COUNT" -ge "$MAX_BLOCKS" ]]; then
   echo '{"blocks": 0}' > "$STATE_FILE" 2>/dev/null || true
-  echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
   exit 0
 fi
 
@@ -214,5 +214,5 @@ if [[ "$HAS_ACTIVE_PLAN" == true ]]; then
 fi
 
 # --- No match: approve ---
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 exit 0

--- a/.claude/hooks/auto-format-prettier.sh
+++ b/.claude/hooks/auto-format-prettier.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # auto-format-prettier.sh - Auto-format JS/TS files with Prettier after edits
 # VERSION: 2.69.1
 # v2.68.9: SEC-102 FIX - Validate FILE_PATH to prevent command injection

--- a/.claude/hooks/auto-sync-global.sh
+++ b/.claude/hooks/auto-sync-global.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 # Cost was ~600ms synchronously; now returns in ~5ms and the sync runs in the
 # background. A project that needs first-time sync self-heals within this session.
 if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
-    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >/dev/null 2>&1 &
+    mkdir -p "${HOME}/.ralph/logs" 2>/dev/null || true
+    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >>"${HOME}/.ralph/logs/auto-sync-global.bg.log" 2>&1 &
     disown 2>/dev/null || true
     exit 0
 fi

--- a/.claude/hooks/auto-sync-global.sh
+++ b/.claude/hooks/auto-sync-global.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
+umask 077
 # Auto-sync global commands/agents/hooks to current project
 # Runs on SessionStart to ensure all projects have global configs
 
 # VERSION: 2.85.0
 set -euo pipefail
+
+# PERF v3.1.1: SessionStart symlink sync — run detached so startup never blocks.
+# Cost was ~600ms synchronously; now returns in ~5ms and the sync runs in the
+# background. A project that needs first-time sync self-heals within this session.
+if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
+    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+    exit 0
+fi
 
 GLOBAL_DIR="${HOME}/.claude"
 

--- a/.claude/hooks/batch-progress-tracker.sh
+++ b/.claude/hooks/batch-progress-tracker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # batch-progress-tracker.sh - Track batch execution progress
 # Version: 2.88.0
 # Trigger: PostToolUse (Task, TaskUpdate, TaskCreate)

--- a/.claude/hooks/checkpoint-smart-save.sh
+++ b/.claude/hooks/checkpoint-smart-save.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # checkpoint-smart-save.sh - Smart checkpoint based on risk/complexity
 # VERSION: 2.84.3
 # v2.69.0: VERSION sync - all CRIT-003b fixes were already in place

--- a/.claude/hooks/command-router.sh
+++ b/.claude/hooks/command-router.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # command-router.sh - Unified Prompt Analysis Hook
 # VERSION: 2.0.0
 # Hook: UserPromptSubmit

--- a/.claude/hooks/console-log-detector.sh
+++ b/.claude/hooks/console-log-detector.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # console-log-detector.sh - Warn about console.log statements after JS/TS edits
 # VERSION: 2.69.1
 # HOOK: PostToolUse (Edit|Write)

--- a/.claude/hooks/context-mode-cache-heal.mjs
+++ b/.claude/hooks/context-mode-cache-heal.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// context-mode plugin cache self-heal (auto-deployed)
+// Fixes anthropics/claude-code#46915: auto-update breaks CLAUDE_PLUGIN_ROOT
+// Issue #727: also normalizes stale version paths in existing installPaths
+// Honors CLAUDE_CONFIG_DIR (#577) — checked at this script's runtime so users
+// who set CLAUDE_CONFIG_DIR after install still get healed correctly.
+// Pure Node.js — no bash/shell dependency.
+import{existsSync,readdirSync,statSync,symlinkSync,lstatSync,unlinkSync,readFileSync}from"node:fs";
+import{dirname,join,resolve,sep}from"node:path";
+import{homedir}from"node:os";
+function cfgDir(){const e=process.env.CLAUDE_CONFIG_DIR;if(e&&e.trim()!==""){return e.startsWith("~")?resolve(homedir(),e.replace(/^~[/\\]?/,"")):resolve(e)}return resolve(homedir(),".claude")}
+try{
+  const f=resolve(cfgDir(),"plugins","installed_plugins.json");
+  if(!existsSync(f))process.exit(0);
+  const cacheRoot=resolve(cfgDir(),"plugins","cache");
+  const ip=JSON.parse(readFileSync(f,"utf-8"));
+  for(const[k,es]of Object.entries(ip.plugins||{})){
+    if(k!=="context-mode@context-mode")continue;
+    for(const e of es){
+      const p=e.installPath;
+      if(!p)continue;
+      if(!resolve(p).startsWith(cacheRoot+sep))continue;
+      if(existsSync(p)){
+        // Issue #727: normalize stale version paths in existing installPaths.
+        // CC's auto-update can carry forward hooks.json/plugin.json with paths
+        // baked to a previous version dir. Import normalize-hooks from the
+        // installPath itself and let it detect + rewrite stale segments.
+        try{
+          // #713: narrow helper only — installPath belongs to a different
+          // version's cache dir; writing plugin.json there is the #711 vector.
+          const nhPath=join(p,"hooks","normalize-hooks.mjs");
+          if(existsSync(nhPath)){
+            const mod=await import(nhPath);
+            const fn=mod.normalizeHooksJsonOnly||mod.normalizeHooksOnStartup;
+            if(fn)fn({pluginRoot:p,nodePath:process.execPath,platform:process.platform});
+          }
+        }catch{}
+        continue;
+      }
+      const parent=dirname(p);
+      if(!existsSync(parent))continue;
+      try{if(lstatSync(p).isSymbolicLink())unlinkSync(p)}catch{}
+      const dirs=readdirSync(parent).filter(d=>/^\d+\.\d+/.test(d)&&statSync(join(parent,d)).isDirectory());
+      if(!dirs.length)continue;
+      dirs.sort((a,b)=>{const pa=a.split(".").map(Number),pb=b.split(".").map(Number);for(let i=0;i<3;i++){if((pa[i]||0)!==(pb[i]||0))return(pa[i]||0)-(pb[i]||0)}return 0});
+      try{symlinkSync(join(parent,dirs[dirs.length-1]),p,process.platform==="win32"?"junction":undefined)}catch{}
+    }
+  }
+}catch{}

--- a/.claude/hooks/context-warning.sh
+++ b/.claude/hooks/context-warning.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # ~/.claude/hooks/context-warning.sh
 # Context Monitoring Hook - v2.90.0
 # Executed on every user-prompt-submit to monitor context usage
@@ -166,17 +167,11 @@ get_context_percentage() {
         fi
     fi
 
-    # Method 2: Try native CLI command (works in full CLI mode)
-    # SEC-029: Added 3s timeout to prevent hook timeout (exit code 124)
-    if [[ -z "$pct" ]] && [[ "$CAPABILITIES" == "full" ]]; then
-        local context_output
-        context_output=$(timeout 3 claude --print "/context" 2>/dev/null || echo "unknown")
-
-        if [[ "$context_output" =~ ([0-9]+\.?[0-9]*)% ]]; then
-            pct="${BASH_REMATCH[1]}"
-            log_context "DEBUG" "Method 2 (/context command): $pct%"
-        fi
-    fi
+    # Method 2 (DISABLED v3.1.1 — PERF): recursive `claude --print "/context"` cost
+    # ~3-4s on EVERY UserPromptSubmit (CLI cold-start + 3s timeout cap). Transcript
+    # estimation (Method 1.5) and the message-count fallback (Method 3) replace it at
+    # ~zero cost. Kept as an explicit no-op to preserve method numbering and intent.
+    : # no-op — do NOT reintroduce a recursive `claude` subprocess in a hot-path hook
 
     # Method 3: Session-scoped message count (minimal fallback)
     # v3.1.0: Model-aware cap — GLM models cap at lower percentage

--- a/.claude/hooks/continuous-learning.sh
+++ b/.claude/hooks/continuous-learning.sh
@@ -20,7 +20,7 @@ umask 077
 # SEC-033: Guaranteed JSON output on any error
 # Stop hooks use {"decision": "approve"} format
 output_json() {
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 }
 trap 'output_json' ERR EXIT
 
@@ -43,7 +43,7 @@ TRANSCRIPT="${HOME}/.claude/projects/${CLAUDE_PROJECT_ID:-default}/${SESSION_ID}
 # Skip if transcript doesn't exist or is too short
 if [[ ! -f "$TRANSCRIPT" ]]; then
     trap - EXIT
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -53,7 +53,7 @@ MSG_COUNT=$(wc -l < "$TRANSCRIPT" 2>/dev/null || echo "0")
 # Only analyze sessions with 10+ messages
 if [[ $MSG_COUNT -lt 10 ]]; then
     trap - EXIT
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -129,4 +129,4 @@ EOF
 fi
 
 trap - EXIT
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed

--- a/.claude/hooks/glm-context-update.sh
+++ b/.claude/hooks/glm-context-update.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # glm-context-update.sh - GLM-4.7 context tracking and update (consolidated)
 # VERSION: 3.0.0 (Consolidated from glm-context-update.sh + glm-context-tracker.sh)
 # Hook: PostToolUse (Edit|Write|Bash)

--- a/.claude/hooks/inject-session-context.sh
+++ b/.claude/hooks/inject-session-context.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # inject-session-context.sh - PreToolUse Hook for Ralph v2.62.3
 # Hook: PreToolUse (Task)
 # Injects session context before Task tool calls

--- a/.claude/hooks/lsa-pre-step.sh
+++ b/.claude/hooks/lsa-pre-step.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 #!/usr/bin/env bash
 # VERSION: 2.84.3
 # LSA Pre-Step Verification

--- a/.claude/hooks/orchestrator-report.sh
+++ b/.claude/hooks/orchestrator-report.sh
@@ -27,7 +27,7 @@ INPUT=$(head -c 100000)
 set -euo pipefail
 
 # Error trap for guaranteed JSON output (v2.62.3)
-trap 'echo "{\"decision\": \"approve\"}"' ERR EXIT
+: # FIXED: trap invalid decision approve removed
 
 umask 077
 
@@ -240,4 +240,4 @@ log "=== Report Generation Complete ==="
 # SEC-039: Stop hooks MUST use "decision": "approve" or "decision": "block"
 # CRIT-003: Clear trap before explicit JSON output to avoid duplicates
 trap - ERR EXIT
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed

--- a/.claude/hooks/periodic-reminder.sh
+++ b/.claude/hooks/periodic-reminder.sh
@@ -79,8 +79,10 @@ is_numeric() {
 # Get current context usage percentage
 # ============================================================================
 get_context_percentage() {
-    local context_output
-    context_output=$(claude --print "/context" 2>/dev/null || echo "unknown")
+    # PERF v3.1.1: recursive `claude --print "/context"` removed. It had NO timeout here,
+    # so it could block this UserPromptSubmit hook indefinitely (root-cause family of the
+    # 4.4s/message bug). Fall through to the message-count estimate below.
+    local context_output="unknown"
 
     # Parse percentage - support decimals: NN% or N.N%
     if [[ "$context_output" =~ ([0-9]+\.?[0-9]*)% ]]; then

--- a/.claude/hooks/periodic-reminder.sh
+++ b/.claude/hooks/periodic-reminder.sh
@@ -79,20 +79,29 @@ is_numeric() {
 # Get current context usage percentage
 # ============================================================================
 get_context_percentage() {
-    # PERF v3.1.1: recursive `claude --print "/context"` removed. It had NO timeout here,
-    # so it could block this UserPromptSubmit hook indefinitely (root-cause family of the
-    # 4.4s/message bug). Fall through to the message-count estimate below.
-    local context_output="unknown"
+    # PERF v3.1.1 + fix: recursive `claude --print "/context"` removed (no timeout — could
+    # block this hook indefinitely). Read the authoritative context % from the hook's stdin
+    # JSON (same source as context-warning.sh Method 1); fall back to the POPULATED counter.
+    local pct=""
+    if [[ -n "$INPUT" ]] && command -v jq &>/dev/null; then
+        local remaining_pct used_pct
+        remaining_pct=$(printf '%s' "$INPUT" | jq -r '.context_window.remaining_percentage // empty' 2>/dev/null)
+        if [[ "$remaining_pct" =~ ^[0-9]+$ ]]; then
+            pct=$((100 - remaining_pct))
+        else
+            used_pct=$(printf '%s' "$INPUT" | jq -r '.context_window.used_percentage // empty' 2>/dev/null)
+            [[ "$used_pct" =~ ^[0-9]+$ ]] && pct="$used_pct"
+        fi
+    fi
 
-    # Parse percentage - support decimals: NN% or N.N%
-    if [[ "$context_output" =~ ([0-9]+\.?[0-9]*)% ]]; then
-        local pct="${BASH_REMATCH[1]}"
+    if [[ -n "$pct" ]]; then
         # Clamp to 0-100 range
         awk -v val="$pct" 'BEGIN { printf "%.0f\n", (val > 100 ? 100 : (val < 0 ? 0 : val)) }'
     else
-        # Fallback: estimate based on message count
+        # Fallback: estimate from the POPULATED counter. The bare ${RALPH_DIR}/message_count
+        # is never written by any hook; the real counter lives under state/.
         local message_count
-        message_count=$(safe_read_file "${RALPH_DIR}/message_count")
+        message_count=$(safe_read_file "${RALPH_DIR}/state/message_count")
         if ! is_numeric "$message_count" || [ -z "$message_count" ]; then
             message_count=0
         fi

--- a/.claude/hooks/plan-state-lifecycle.sh
+++ b/.claude/hooks/plan-state-lifecycle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # plan-state-lifecycle.sh - Manage plan-state lifecycle
 # VERSION: 2.69.0
 # v2.68.11: SEC-111 FIX - Input length validation to prevent DoS

--- a/.claude/hooks/plan-sync-post-step.sh
+++ b/.claude/hooks/plan-sync-post-step.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # VERSION: 2.70.0
 # Hook: Plan-Sync Post-Step
 # Trigger: PostToolUse (after Edit or Write completes in orchestrated context)

--- a/.claude/hooks/post-compact-restore.sh
+++ b/.claude/hooks/post-compact-restore.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # VERSION: 2.85.0
 # post-compact-restore.sh - Multi-Agent Ralph v2.85.0
 # Restores context and plan state after compaction

--- a/.claude/hooks/pre-compact-handoff.sh
+++ b/.claude/hooks/pre-compact-handoff.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # pre-compact-handoff.sh - PreCompact Hook for Ralph v2.68.8
 # Hook: PreCompact
 # Auto-saves state BEFORE context compaction to prevent information loss

--- a/.claude/hooks/progress-tracker.sh
+++ b/.claude/hooks/progress-tracker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # progress-tracker.sh - PostToolUse Hook for Ralph v2.62.3
 # Hook: PostToolUse (Edit|Write|Bash)
 # Auto-registro de intentos/errores en .claude/progress.md por proyecto

--- a/.claude/hooks/project-backup-metadata.sh
+++ b/.claude/hooks/project-backup-metadata.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # project-backup-metadata.sh - SessionStart/Stop hooks for project metadata backup
 # VERSION: 2.85.0
 #
@@ -24,7 +25,7 @@ set -euo pipefail
 
 # SEC-033: Guaranteed JSON output on any error
 output_json_stop() {
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 }
 trap 'output_json_stop' ERR
 
@@ -311,11 +312,11 @@ case "$HOOK_TYPE" in
             log "No current session found to backup"
         fi
 
-        echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
         ;;
 
     *)
         echo "Unknown hook type: $HOOK_TYPE"
-        echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
         ;;
 esac

--- a/.claude/hooks/project-state.sh
+++ b/.claude/hooks/project-state.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # project-state.sh - Unified project state: skills sync validation + context tracking
 # VERSION: 1.0.0 (Consolidated from skills-sync-validator.sh + unified-context-tracker.sh)
 # Hook: SessionStart (matcher: *)
@@ -82,8 +83,10 @@ validate_skills() {
 
     # Check for broken symlinks in global
     local broken_global broken_agents
-    broken_global=$(find "$GLOBAL_SKILLS" -maxdepth 1 -type l ! -exec test -e {} \; -print 2>/dev/null | wc -l | tr -d ' ')
-    broken_agents=$(find "$AGENTS_SKILLS" -maxdepth 1 -type l ! -exec test -e {} \; -print 2>/dev/null | wc -l | tr -d ' ')
+    # PERF v3.1.1: `find -L ... -type l` lists ONLY broken symlinks (those -L cannot
+    # resolve) without spawning a `test` process per symlink — same result, far faster.
+    broken_global=$(find -L "$GLOBAL_SKILLS" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
+    broken_agents=$(find -L "$AGENTS_SKILLS" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
 
     # Determine issues
     local issues=()
@@ -182,9 +185,9 @@ get_percentage() {
             fi
             ;;
         claude)
-            # Try native Claude context command
-            local pct
-            pct=$(timeout 3 claude --print "/context" 2>/dev/null | grep -o '[0-9]*%' | tr -d '%' || echo "")
+            # PERF v3.1.1: recursive `claude --print "/context"` removed (cost 3-4s on
+            # SessionStart). Fall through to the operation/message-count estimate below.
+            local pct=""
 
             if [[ -z "$pct" ]] || [[ "$pct" == "0" ]]; then
                 local ops msgs

--- a/.claude/hooks/promptify-security.sh
+++ b/.claude/hooks/promptify-security.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # promptify-security.sh - Security hardening functions for Promptify integration
 # VERSION: 1.0.0
 # Purpose: Credential redaction, clipboard consent, agent timeout, audit logging

--- a/.claude/hooks/quality-parallel-async.sh
+++ b/.claude/hooks/quality-parallel-async.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # Quality Parallel Async Hook - FIXED VERSION
 # VERSION: 2.1.0
 # FIX v2.1.0: All MEDIUM + LOW priority fixes applied

--- a/.claude/hooks/ralph-stop-quality-gate.sh
+++ b/.claude/hooks/ralph-stop-quality-gate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # ralph-stop-quality-gate.sh - Quality gate for Stop event
 # VERSION: 2.88.0
 # REPO: multi-agent-ralph-loop
@@ -66,7 +67,7 @@ STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
     # Claude is already continuing from a previous block
     # MUST allow stop to prevent infinite loop
-    echo '{"decision": "approve", "reason": "Previous block already active - allowing stop to prevent infinite loop"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -91,7 +92,7 @@ if [[ ! -f "$SESSION_FILE" ]]; then
     if [[ -n "$STATE_DIR" && "$STATE_DIR" == *"/.ralph/"* ]]; then
         find "$STATE_DIR" -mindepth 2 -name "session.json" -mtime +1 -delete 2>/dev/null || true
     fi
-    echo '{"decision": "approve", "reason": "No active session"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -100,7 +101,7 @@ SESSION_AGE=$(jq -r '.age_seconds // 0' "$SESSION_FILE" 2>/dev/null || echo "0")
 if [[ "$SESSION_AGE" -gt "$SESSION_MAX_AGE" ]]; then
     # Stale session, cleanup and allow stop
     rm -rf "$STATE_DIR/${SESSION_ID}" 2>/dev/null || true
-    echo '{"decision": "approve", "reason": "Stale session cleaned up"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -294,11 +295,11 @@ if [ -n "$BLOCKING_ISSUES" ]; then
     exit 2
 elif [ -n "$ADVISORY_ISSUES" ]; then
     # Advisory issues don't block, but log them
-    echo '{"decision": "approve", "reason": "All blocking conditions met (advisory issues noted)"}'
+: # FIXED: invalid decision approve removed
     exit 0
 else
     # All conditions met, allow stop
-    echo '{"decision": "approve", "reason": "All VERIFIED_DONE conditions met"}'
+: # FIXED: invalid decision approve removed
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Stop APPROVED: All conditions met" >> "$LOG_DIR/stop-hook.log"
     exit 0
 fi

--- a/.claude/hooks/ralph-subagent-start.sh
+++ b/.claude/hooks/ralph-subagent-start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # ralph-subagent-start.sh - Initialize subagents with Ralph context, memory, and integration
 # VERSION: 2.95.0
 # REPO: multi-agent-ralph-loop

--- a/.claude/hooks/ralph-subagent-stop.sh
+++ b/.claude/hooks/ralph-subagent-stop.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # ralph-subagent-stop.sh - Quality gate for ralph-* subagent termination
 # VERSION: 2.95.0
 # Event: SubagentStop
@@ -46,7 +47,7 @@ if [[ -f "$SUBAGENT_STATE" ]]; then
     if [[ "$STATUS" == "working" ]]; then
         log "BLOCK: Subagent $SUBAGENT_ID still working"
         cat <<EOF
-{"decision": "block", "reason": "Subagent still has active work", "feedback": "Complete your assigned tasks before stopping"}
+{"decision": "block", "reason": "Subagent still has active work"}
 EOF
         exit 2
     fi
@@ -65,7 +66,7 @@ if [[ -n "$TASK_ID" ]]; then
             if [[ "$TASK_STATUS" == "pending" || "$TASK_STATUS" == "in_progress" ]]; then
                 log "BLOCK: Task $TASK_ID not completed (status: $TASK_STATUS)"
                 cat <<EOF
-{"decision": "block", "reason": "Assigned task not completed", "feedback": "Task $TASK_ID is still $TASK_STATUS. Mark it complete or report blockers."}
+{"decision": "block", "reason": "Assigned task not completed"}
 EOF
                 exit 2
             fi
@@ -81,7 +82,7 @@ if [[ -f "$QUALITY_STATE" ]]; then
         GATE_REASON=$(jq -r '.reason // "Unknown quality issue"' "$QUALITY_STATE" 2>/dev/null)
         log "BLOCK: Quality gate failed - $GATE_REASON"
         cat <<EOF
-{"decision": "block", "reason": "Quality gate failed", "feedback": "$GATE_REASON - Fix quality issues before stopping"}
+{"decision": "block", "reason": "Quality gate failed"}
 EOF
         exit 2
     fi
@@ -154,8 +155,8 @@ fi
 
 # Output approval with cleanup info
 if [[ -n "$CLEANUP_INFO" ]]; then
-  echo "{\"decision\": \"approve\", \"reason\": \"All subagent tasks completed and quality gates passed\", \"cleanup\": \"$CLEANUP_INFO\"}"
+: # FIXED: invalid decision approve removed
 else
-  echo "{\"decision\": \"approve\", \"reason\": \"All subagent tasks completed and quality gates passed\"}"
+: # FIXED: invalid decision approve removed
 fi
 exit 0

--- a/.claude/hooks/repo-boundary-guard.sh
+++ b/.claude/hooks/repo-boundary-guard.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # repo-boundary-guard.sh - Repository Isolation Enforcement
 # Hook: PreToolUse (Edit|Write|Bash)
 # Purpose: Prevent accidental work in external repositories

--- a/.claude/hooks/sentry-report.sh
+++ b/.claude/hooks/sentry-report.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # Hook: Stop (sentry-report)
 # Generates Sentry summary report at orchestrator completion
 # Once: true
@@ -14,13 +15,13 @@ INPUT=$(head -c 100000)
 
 
 # SEC-039: Guaranteed valid JSON output on any error (Stop hook format)
-trap 'echo '"'"'{"decision": "approve"}'"'"'' ERR EXIT
+: # FIXED: trap invalid decision approve removed
 
 # Only run if Sentry was used in this session
 if [[ ! -f ".sentry-used" ]]; then
     # CRIT-003: Clear trap before explicit JSON output to avoid duplicates
     trap - ERR EXIT
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -44,5 +45,5 @@ rm -f ".sentry-used"
 # Stop hook must output JSON
 # CRIT-003: Clear trap before explicit JSON output to avoid duplicates
 trap - ERR EXIT
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 exit 0

--- a/.claude/hooks/session-accumulator.sh
+++ b/.claude/hooks/session-accumulator.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # session-accumulator.sh — Captures learnings during a session
 # Event: PostToolUse (Edit|Write)
 # VERSION: 3.1.0

--- a/.claude/hooks/session-end-handoff.sh
+++ b/.claude/hooks/session-end-handoff.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # session-end-handoff.sh - SessionEnd Hook for Ralph v2.85.0
 # Hook: SessionEnd
 # Auto-saves state BEFORE session terminates to enable seamless continuation

--- a/.claude/hooks/session-start-restore-context.sh
+++ b/.claude/hooks/session-start-restore-context.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # session-start-restore-context.sh - SessionStart Hook for Ralph v3.2.0
 # Hook: SessionStart
 # Restores context and plan state when a new session starts

--- a/.claude/hooks/skill-validator.sh
+++ b/.claude/hooks/skill-validator.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # skill-validator.sh - Validate YAML-based skills before execution
 # Hook: PreToolUse (Skill)
 # v2.62.3 - Part of lightweight skills system (H70-inspired)

--- a/.claude/hooks/status-auto-check.sh
+++ b/.claude/hooks/status-auto-check.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # status-auto-check.sh - Auto-show status periodically
 # VERSION: 2.69.0
 # v2.57.3: Fixed LAST remaining wrong format on line 119 (SEC-036)

--- a/.claude/hooks/stop-slop-hook.sh
+++ b/.claude/hooks/stop-slop-hook.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 #!/usr/bin/env bash
 # Stop-Slop Hook - Detects AI writing patterns
 # VERSION: 1.0.2

--- a/.claude/hooks/subagent-stop-universal.sh
+++ b/.claude/hooks/subagent-stop-universal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+umask 077
 # subagent-stop-universal.sh - Universal quality gate for ALL subagent termination
 # VERSION: 2.90.1
 # Event: SubagentStop
@@ -116,6 +117,6 @@ fi
 
 log "APPROVE: Subagent ${agent_id} (${agent_type}) can stop"
 cat <<EOF
-{"decision": "approve", "reason": "Subagent completion verified (model-agnostic)"}
+: # FIXED: bare JSON decision approve removed
 EOF
 exit 0

--- a/.claude/hooks/task-completed-quality-gate.sh
+++ b/.claude/hooks/task-completed-quality-gate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # task-completed-quality-gate.sh - Quality gate before task completion
 # VERSION: 2.90.0
 # REPO: multi-agent-ralph-loop
@@ -18,7 +19,7 @@
 #
 # Output (stdout JSON):
 #   {"decision": "approve", "reason": "All acceptance criteria verified"}
-#   {"decision": "request_changes", "reason": "Task incomplete", "feedback": "..."}
+#   {"decision": "request_changes", "reason": "Task incomplete"}
 
 set -euo pipefail
 

--- a/.claude/hooks/task-orchestration-optimizer.sh
+++ b/.claude/hooks/task-orchestration-optimizer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # task-orchestration-optimizer.sh - Optimize Task tool usage patterns
 # VERSION: 2.84.3
 # v2.69.0: FIX CRIT-003 - Added EXIT to trap for guaranteed JSON output

--- a/.claude/hooks/teammate-idle-quality-gate.sh
+++ b/.claude/hooks/teammate-idle-quality-gate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # teammate-idle-quality-gate.sh - Quality gate for Agent Teams teammates
 # VERSION: 2.90.0
 # REPO: multi-agent-ralph-loop
@@ -18,7 +19,7 @@
 #
 # Output (stdout JSON):
 #   {"decision": "approve", "reason": "All quality checks passed"}
-#   {"decision": "request_changes", "reason": "Quality issues found", "feedback": "..."}
+#   {"decision": "request_changes", "reason": "Quality issues found"}
 
 set -euo pipefail
 

--- a/.claude/hooks/todo-plan-sync.sh
+++ b/.claude/hooks/todo-plan-sync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # VERSION: 2.84.2
 # PostToolUse hook for TodoWrite - Sync todos with plan-state progress
 #

--- a/.claude/hooks/vault-graduation.sh
+++ b/.claude/hooks/vault-graduation.sh
@@ -14,7 +14,8 @@ umask 077
 # The full-vault scan cost ~2s synchronously; now the hook returns in ~5ms and the
 # scan/graduation runs in the background. Status JSON is dropped in background mode.
 if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
-    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >/dev/null 2>&1 &
+    mkdir -p "${HOME}/.ralph/logs" 2>/dev/null || true
+    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >>"${HOME}/.ralph/logs/vault-graduation.bg.log" 2>&1 &
     disown 2>/dev/null || true
     exit 0
 fi

--- a/.claude/hooks/vault-graduation.sh
+++ b/.claude/hooks/vault-graduation.sh
@@ -10,6 +10,15 @@
 set -euo pipefail
 umask 077
 
+# PERF v3.1.1: SessionStart maintenance — run detached so startup never blocks.
+# The full-vault scan cost ~2s synchronously; now the hook returns in ~5ms and the
+# scan/graduation runs in the background. Status JSON is dropped in background mode.
+if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
+    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+    exit 0
+fi
+
 # Safety: always output valid JSON for SessionStart
 trap 'echo "{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"vault-graduation: error\"}}"' ERR INT TERM
 

--- a/.claude/hooks/vault-index-updater.sh
+++ b/.claude/hooks/vault-index-updater.sh
@@ -13,13 +13,13 @@ set -euo pipefail
 umask 077
 
 # Safety: always output valid JSON for SessionEnd
-trap 'echo "{\"decision\": \"approve\"}"' ERR INT TERM
+: # FIXED: trap invalid decision approve removed
 
 VAULT_DIR="${VAULT_DIR:-$HOME/Documents/Obsidian/MiVault}"
 
 # Skip if vault doesn't exist
 if [[ ! -d "$VAULT_DIR" ]]; then
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -128,4 +128,4 @@ total_decisions=$(find "$VAULT_DIR/global/decisions" -name "*.md" -type f 2>/dev
     echo "- [Project Index](projects/_project-index.md)"
 } > "$VAULT_INDEX" 2>/dev/null || true
 
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed

--- a/.claude/hooks/vault-log-writer.sh
+++ b/.claude/hooks/vault-log-writer.sh
@@ -51,7 +51,7 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null | tr -
 # ---------------------------------------------------------------------------
 if [[ ! -d "$VAULT_DIR" ]]; then
     log "WARN vault missing, skipping log write"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -133,6 +133,6 @@ fi
 # ---------------------------------------------------------------------------
 # Output SessionEnd format
 # ---------------------------------------------------------------------------
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 
 exit 0

--- a/.claude/hooks/vault-promotion.sh
+++ b/.claude/hooks/vault-promotion.sh
@@ -24,6 +24,15 @@
 set -euo pipefail
 umask 077
 
+# PERF v3.1.1: SessionStart maintenance (wiki promotion + diary scan) — run detached
+# so startup never blocks. Cost was ~700ms synchronously; now returns in ~5ms and the
+# promotion work runs in the background. Status JSON is dropped in background mode.
+if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
+    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+    exit 0
+fi
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/vault-promotion.sh
+++ b/.claude/hooks/vault-promotion.sh
@@ -28,7 +28,8 @@ umask 077
 # so startup never blocks. Cost was ~700ms synchronously; now returns in ~5ms and the
 # promotion work runs in the background. Status JSON is dropped in background mode.
 if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
-    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >/dev/null 2>&1 &
+    mkdir -p "${HOME}/.ralph/logs" 2>/dev/null || true
+    RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >>"${HOME}/.ralph/logs/vault-promotion.bg.log" 2>&1 &
     disown 2>/dev/null || true
     exit 0
 fi

--- a/.claude/hooks/vault-wing-compiler.sh
+++ b/.claude/hooks/vault-wing-compiler.sh
@@ -55,7 +55,7 @@ if command -v git &>/dev/null; then
     REPO_ROOT="${HOME}/Documents/GitHub/multi-agent-ralph-loop"
     PROJECT=$(basename "$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null || echo "")" 2>/dev/null || echo "unknown")
 fi
-[[ -z "$PROJECT" || "$PROJECT" == "unknown" ]] && { log "WARN no project detected"; echo '{"decision": "approve"}'; exit 0; }
+: # FIXED: invalid decision approve removed
 
 # Sanitize project name for filesystem
 SAFE_PROJECT=$(echo "$PROJECT" | tr -cd 'a-zA-Z0-9_-' | head -c 64)
@@ -68,7 +68,7 @@ FACTS_FILE="${VAULT_DIR}/projects/${PROJECT}/facts/facts-${TODAY}.md"
 
 if [[ ! -f "$FACTS_FILE" ]]; then
     log "INFO no facts file for today: ${FACTS_FILE}"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -89,7 +89,7 @@ done < "$FACTS_FILE"
 
 if [[ -z "$NEW_FACTS" ]]; then
     log "INFO no valid categorized facts found"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -117,7 +117,7 @@ done <<< "$NEW_FACTS"
 
 if [[ -z "$DEDUPED_FACTS" ]]; then
     log "INFO all facts already in wing, nothing new"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -182,5 +182,5 @@ else
     log "WARN could not acquire lock for wing write"
 fi
 
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 exit 0

--- a/.claude/hooks/vault-writeback.sh
+++ b/.claude/hooks/vault-writeback.sh
@@ -52,13 +52,13 @@ INPUT=$(head -c 100000)
 # ---------------------------------------------------------------------------
 if [[ ! -d "$VAULT_DIR" ]]; then
     log "WARN vault missing, skipping writeback"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
 if [[ ! -f "$WRITEBACK_QUEUE" ]]; then
     log "INFO no writeback queue, nothing to process"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -71,7 +71,7 @@ QUEUE_LENGTH=$(echo "$QUEUE_CONTENT" | jq 'length' 2>/dev/null || echo "0")
 if [[ "$QUEUE_LENGTH" == "0" || "$QUEUE_LENGTH" == "null" ]]; then
     log "INFO empty writeback queue"
     rm -f "$WRITEBACK_QUEUE"
-    echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
     exit 0
 fi
 
@@ -165,5 +165,5 @@ done
 rm -f "$WRITEBACK_QUEUE"
 
 log "INFO writeback complete processed=${PROCESSED} skipped=${SKIPPED}"
-echo '{"decision": "approve"}'
+: # FIXED: invalid decision approve removed
 exit 0

--- a/.claude/hooks/wake-up-layer-stack.sh
+++ b/.claude/hooks/wake-up-layer-stack.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+umask 077
 # wake-up-layer-stack.sh — SessionStart Hook, Wave 2.2 Layer Stack
 # ================================================================
 #

--- a/docs/hooks/AUDIT-REPORT.md
+++ b/docs/hooks/AUDIT-REPORT.md
@@ -1,0 +1,84 @@
+# Hook Audit Report — multi-agent-ralph-loop
+**Fecha**: 2026-06-14 | **Validator**: API Claude Code actual (docs.claude.com)
+
+## Resumen Ejecutivo
+
+Se encontraron **2 categorias de bugs criticos** causando errores de validacion
+en Claude Code:
+
+| Bug | Ocurrencias | Causa | Impacto |
+|-----|-------------|-------|---------|
+| `{"decision": "approve"}` | 38 en codigo | Formato obsoleto | "Hook JSON output validation failed" |
+| Campos `feedback`/`cleanup` | 5 en codigo | Campos inexistentes | JSON validation error adicional |
+
+**Total**: 13 archivos afectados, 43 correcciones aplicadas.
+
+## Root Cause Analysis
+
+### Bug #1: {"decision": "approve"} — Formato Inexistente
+
+La regla SEC-039 del sistema ralph documentaba:
+> Stop hooks MUST use {"decision": "approve"} or {"decision": "block"}
+
+Esto era valido en una version anterior de Claude Code. La API actual cambio:
+el campo `decision` solo acepta `"block"` o ausente. **No existe "approve"**.
+
+### Bug #2: {"continue": true} — Valido pero Innecesario
+
+~25 hooks emiten `{"continue": true}` que es tecnicamente valido (campo comun)
+pero completamente innecesario — `continue: true` es el default. No causa errores.
+
+### Bug #3: Error de Node.js (cjs/loader:1215)
+
+No reproducible en el repo. Probable causa: un hook en `~/.claude/settings.json`
+que referencia un script .js inexistente o con un require roto. Revisar settings.
+
+## Archivos Corregidos
+
+1. anti-rationalization-gate.sh (4 fixes)
+2. continuous-learning.sh (4 fixes)
+3. orchestrator-report.sh (2 fixes)
+4. project-backup-metadata.sh (3 fixes)
+5. ralph-stop-quality-gate.sh (5 fixes)
+6. ralph-subagent-stop.sh (5 fixes: approve + feedback + cleanup)
+7. sentry-report.sh (3 fixes)
+8. subagent-stop-universal.sh (1 fix)
+9. task-completed-quality-gate.sh (1 fix)
+10. teammate-idle-quality-gate.sh (1 fix)
+11. vault-index-updater.sh (3 fixes)
+12. vault-log-writer.sh (3 fixes)
+13. vault-wing-compiler.sh (5 fixes)
+14. vault-writeback.sh (4 fixes)
+
+## Formato Correcto (Referencia Actual)
+
+### Para PERMITIR/dejar pasar (todos los eventos)
+```bash
+exit 0  # No emitir JSON. Solo salir limpio.
+```
+
+### Stop/SubagentStop — BLOQUEAR
+```bash
+echo '{"decision":"block","reason":"Razon especifica"}'
+exit 0
+```
+
+### PreToolUse — DENEGAR
+```bash
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Razon"}}'
+exit 0
+```
+
+### PostToolUse/UserPromptSubmit/SessionStart — AGREGAR CONTEXTO
+```bash
+echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Contexto"}}'
+exit 0
+```
+
+## Acciones Recomendadas
+
+1. **YA APLICADO**: fix-hook-formats.sh ejecutado en el repo
+2. **Verificar**: Ejecutar validate-hooks-v2.sh antes de cada commit
+3. **Actualizar regla SEC-039**: El formato {"decision": "approve"} es INVALIDO
+4. **Investigar error Node.js**: Revisar ~/.claude/settings.json por hooks .js rotos
+5. **Actualizar tests**: Los tests que esperan {"decision": "approve"} estan mal

--- a/docs/hooks/CONSOLIDATION-MAP.md
+++ b/docs/hooks/CONSOLIDATION-MAP.md
@@ -1,0 +1,78 @@
+# Hook Consolidation Map (deferred plan)
+
+**Date**: 2026-06-14
+**Version**: v3.1.1
+**Status**: DEFERRED — speed/reliability work is DONE; this is the documented plan for a
+future, dedicated consolidation effort.
+
+## Why this is deferred (read before executing)
+
+The v3.1.1 performance pass removed the only real latency offenders (recursive `claude`
+subprocess ×3; synchronous vault scans). After that, **warm hook chains run at ~25ms**
+because the hooks have stateful early-exit guards. Consequence:
+
+> Merging hooks into dispatchers now yields **~0ms latency benefit in steady state**
+> (only ~400ms saved on the first cold spawn). The remaining motivation is
+> **maintainability** (fewer hook entries), not speed.
+
+Do NOT undertake this for performance. Undertake it only if the maintainability win is
+judged worth the regression risk, and only with the test suite
+(`tests/test_hooks_optimization.py`) plus an output-equivalence check as a guard.
+
+## Consolidation candidates (group by SHARED EVENT, never by name prefix)
+
+| Event | Hooks | Safe approach | Risk |
+|-------|-------|---------------|------|
+| `SessionEnd` | vault-index-updater, vault-wing-compiler, vault-log-writer | One **sequential** dispatcher (`vault-session-end.sh`) that runs the 3 in order. Once-per-session, so latency is irrelevant and sequential = no races. | LOW |
+| `PreToolUse Agent\|Task` | 10 hooks (see below) | Move pure side-effects to async-post; sequential or bucketed-parallel dispatcher for the rest. | MED-HIGH |
+| `UserPromptSubmit` | plan-state-adaptive + plan-state-lifecycle (2 plan-state); universal-prompt-classifier + command-router + aristotle-analysis-display (3 prompt-analysis) | Merge each related pair/triple only after confirming no shared-state writes. | MED |
+
+## Agent|Task chain — detailed analysis (the risky one)
+
+Ten hooks, each 40–77ms cold, ~25ms warm. Classification:
+
+| Hook | Role | Notes for consolidation |
+|------|------|-------------------------|
+| permission-guard | GATE | Must stay PreToolUse, blocking. No file writes. |
+| lsa-pre-step | injects context | Keep pre; emits additionalContext. |
+| smart-memory-search | injects context | Keep pre; writes its own memory/ledger files. |
+| inject-session-context | injects context | Keep pre; emits additionalContext. |
+| auto-plan-state | injects context | Keep pre; **writes `$PLAN_STATE`**. |
+| fast-path-check | gate-ish | Keep pre. |
+| skill-validator | validator | Keep pre. |
+| promptify-security | security | Keep pre; writes consent/audit. |
+| orchestrator-auto-learn | **pure side-effect** (0 deny, 0 context) | **Safe to move to PostToolUse:Task async.** Writes `$PLAN_STATE`. |
+| checkpoint-smart-save | **pure side-effect** (0 deny, 0 context) | A **pre-work snapshot** — moving to post defeats its purpose. Keep pre OR redesign. |
+
+### Confirmed hazards
+
+1. **`$PLAN_STATE` race**: `orchestrator-auto-learn` and `auto-plan-state` both write
+   `.claude/plan-state.json`. They are currently SERIAL (safe). Any **parallel** dispatcher
+   MUST serialize these two (or use `flock`).
+2. **Stateful early-exit**: hooks no-op on repeat invocation. Equivalence tests must reset
+   or account for per-session state.
+3. **deny-merge**: a parallel dispatcher must collect each hook's output and propagate any
+   `permissionDecision: deny` (cannot short-circuit once spawned in parallel).
+4. **pre/post semantics**: `checkpoint-smart-save` is a *before-work* snapshot; do not
+   relocate it to PostToolUse without redesign.
+
+## Recommended safe execution order (when picked up)
+
+1. `SessionEnd` sequential dispatcher (lowest risk, do first).
+2. Move `orchestrator-auto-learn` → `PostToolUse:Task` async (pure side-effect, learning
+   belongs post-execution). Removes it from the blocking path and from the `$PLAN_STATE`
+   parallel hazard.
+3. Only then consider an `Agent|Task` dispatcher — bucketed parallel (independent hooks in
+   parallel; the two `$PLAN_STATE` writers serial), with `flock` on plan-state and a
+   deny-merge step.
+4. Gate every step with `tests/test_hooks_optimization.py` + an output-equivalence diff
+   (capture each hook's stdout/exit before and after; assert identical for representative
+   payloads).
+
+## Tooling already in place
+
+- `scripts/hook-optimization/optimize-settings.py` — idempotent settings.json patcher
+  (dry-run default). Extend it with a `--consolidate` mode to swap N hook entries for a
+  dispatcher entry, with the same backup + validate discipline.
+- `tests/test_hooks_optimization.py` — 38 tests (structural + per-hook timing). The
+  per-hook timing assertions and the no-recursive-claude guard are the key regression nets.

--- a/docs/hooks/HOOK_FORMAT_REFERENCE.md
+++ b/docs/hooks/HOOK_FORMAT_REFERENCE.md
@@ -1,0 +1,109 @@
+# Hook JSON Format Reference (Actualizado 2026-06-14)
+
+## El Problema
+
+Los hooks de ralph usaban `{"decision": "approve"}` que **NO EXISTE**
+en la API actual de Claude Code. Esto causaba:
+
+```
+Hook JSON output validation failed — (root): Invalid input
+```
+
+## Formato Correcto por Tipo de Evento
+
+### Regla Universal
+
+**Para PERMITIR/dejar pasar: no emitir JSON, solo `exit 0`.**
+El JSON solo es necesario cuando quieres cambiar el comportamiento.
+
+### PreToolUse
+
+```bash
+# PERMITIR (default):
+exit 0
+
+# DENEGAR (bloquear tool call):
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Razón"}}'
+exit 0
+
+# O usar exit code 2 (más simple):
+echo "Razón del bloqueo" >&2
+exit 2
+```
+
+### PostToolUse
+
+```bash
+# PERMITIR (default):
+exit 0
+
+# Enviar feedback a Claude:
+echo '{"decision":"block","reason":"Problema encontrado"}'
+exit 0
+
+# Agregar contexto:
+echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Info extra"}}'
+exit 0
+```
+
+### Stop / SubagentStop
+
+```bash
+# PERMITIR que Claude pare (default):
+exit 0
+
+# BLOQUEAR (forzar a continuar):
+echo '{"decision":"block","reason":"Aún hay trabajo pendiente"}'
+exit 0
+```
+
+### UserPromptSubmit
+
+```bash
+# PERMITIR (default):
+exit 0
+
+# BLOQUEAR prompt:
+echo '{"decision":"block","reason":"Prompt no permitido"}'
+exit 0
+
+# Agregar contexto:
+echo '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"Contexto adicional"}}'
+exit 0
+```
+
+### SessionStart
+
+```bash
+# Solo agregar contexto (no puede bloquear):
+echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Contexto de inicio"}}'
+exit 0
+```
+
+### SessionEnd / PreCompact
+
+```bash
+# No pueden bloquear. Solo exit 0:
+exit 0
+```
+
+## Campos Válidos
+
+| Campo | Tipo | Eventos | Descripción |
+|-------|------|---------|-------------|
+| `continue` | bool | Todos | Si false, Claude se detiene (default: true) |
+| `decision` | "block" / undefined | Stop, SubagentStop, PostToolUse, UserPromptSubmit | Bloquear acción |
+| `reason` | string | Con `decision: block` | Razón mostrada a Claude |
+| `suppressOutput` | bool | Todos | Ocultar stdout del transcript |
+| `permissionDecision` | "allow"/"deny"/"ask" | PreToolUse | Control de permisos |
+| `additionalContext` | string | UserPromptSubmit, SessionStart, PostToolUse | Contexto para Claude |
+
+## Lo que NUNCA se debe usar
+
+| Patrón | Por qué es inválido |
+|--------|---------------------|
+| `{"decision": "approve"}` | "approve" NO es un valor válido. Usar exit 0. |
+| `{"decision": "continue"}` | "continue" NO es un valor de decision. |
+| `{"feedback": "..."}` | Campo inexistente. Usar `reason`. |
+| `{"cleanup": "..."}` | Campo inexistente. |
+| `{"decision": "allow"}` en Stop hooks | Stop no usa permissionDecision. Usar exit 0. |

--- a/fix-hook-formats.sh
+++ b/fix-hook-formats.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fix-hook-formats.sh — Corrige formatos JSON invalidos en hooks de Claude Code
+# Bug: {"decision": "approve"} es INVALIDO en la API actual
+# Sintoma: "Hook JSON output validation failed — (root): Invalid input"
+# Fix: Reemplazar con exit 0 (no output) que es el comportamiento correcto
+#
+# Uso: bash fix-hook-formats.sh /path/to/.claude/hooks [--dry-run]
+
+HOOKS_DIR="${1:-}"
+DRY_RUN="${2:-}"
+
+if [ -z "$HOOKS_DIR" ]; then
+  echo "Uso: bash fix-hook-formats.sh /path/to/hooks [--dry-run]"
+  exit 1
+fi
+
+if [ ! -d "$HOOKS_DIR" ]; then
+  echo "ERROR: $HOOKS_DIR no existe"
+  exit 1
+fi
+
+python3 - "$HOOKS_DIR" "$DRY_RUN" << 'PYEOF'
+import sys, os, re, glob
+
+dry_run = '--dry-run' in sys.argv
+class S:
+    files = 0; fixes = 0; log = []
+s = S()
+
+def fix_file(path):
+    with open(path, 'r', errors='replace') as f:
+        lines = f.readlines()
+    changed = False
+    fixes_in_file = []
+    new_lines = []
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        is_comment = stripped.startswith('#')
+        has_approve = 'approve' in line and 'decision' in line
+
+        # 1. trap lines with decision/approve
+        if 'trap' in stripped and has_approve and not is_comment:
+            line = ': # FIXED: trap invalid decision approve removed\n'
+            changed = True; fixes_in_file.append(f"L{i+1}: trap → removed")
+
+        # 2. echo/printf with decision/approve (all quoting)
+        elif not is_comment and has_approve and ('echo' in stripped or 'printf' in stripped):
+            line = ': # FIXED: invalid decision approve removed\n'
+            changed = True; fixes_in_file.append(f"L{i+1}: echo approve → removed")
+
+        # 3. bare JSON line with decision/approve
+        elif not is_comment and has_approve and stripped.startswith('{'):
+            line = ': # FIXED: bare JSON decision approve removed\n'
+            changed = True; fixes_in_file.append(f"L{i+1}: bare JSON → removed")
+
+        # 4. Remove invalid "feedback" field
+        if '"feedback"' in line and 'decision' in line:
+            line = re.sub(r',\s*\\?"feedback\\?":\s*\\?"[^"\\]*?\\?"', '', line)
+            if 'feedback' not in line:
+                changed = True; fixes_in_file.append(f"L{i+1}: feedback field → removed")
+
+        # 5. Remove invalid "cleanup" field
+        if '"cleanup"' in line and 'decision' in line:
+            line = re.sub(r',\s*\\?"cleanup\\?":\s*\\?"[^"\\]*?\\?"', '', line)
+            if 'cleanup' not in line:
+                changed = True; fixes_in_file.append(f"L{i+1}: cleanup field → removed")
+
+        new_lines.append(line)
+
+    if changed:
+        if not dry_run:
+            with open(path, 'w') as f:
+                f.writelines(new_lines)
+        s.files += 1; s.fixes += len(fixes_in_file)
+        s.log.append((os.path.basename(path), fixes_in_file))
+    return changed
+
+files = sorted(set(
+    glob.glob(os.path.join(sys.argv[1], '**', '*.sh'), recursive=True) +
+    glob.glob(os.path.join(sys.argv[1], '**', '*.py'), recursive=True) +
+    glob.glob(os.path.join(sys.argv[1], '**', '*.js'), recursive=True)
+))
+
+print(f"Escaneando {len(files)} archivos...\n")
+for fp in files:
+    if fix_file(fp):
+        prefix = "WOULD FIX" if dry_run else "  ✅ FIXED"
+        print(f"  {prefix}: {os.path.basename(fp)}")
+
+print(f"\n{'='*60}")
+print(f"Archivos: {s.files} | Correcciones: {s.fixes}")
+if s.log:
+    print("\nDetalle:")
+    for fname, fixes in s.log:
+        print(f"  {fname}:")
+        for f in fixes: print(f"    {f}")
+if dry_run:
+    print("\n  Dry-run — ejecuta sin --dry-run para aplicar.")
+else:
+    print("\n  ✅ Correcciones aplicadas.")
+PYEOF

--- a/scripts/hook-optimization/optimize-settings.py
+++ b/scripts/hook-optimization/optimize-settings.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+optimize-settings.py — Safe, idempotent hardener for ~/.claude/settings.json hooks.
+
+What it does (mechanical, low-risk):
+  1. Adds an event-appropriate `timeout` (seconds) to every hook entry that lacks one,
+     so a hung hook degrades to a bounded wait instead of Claude Code's 60s default.
+  2. Fixes the fragile escaped-double-quote `.mjs` SessionStart command
+     ("\"/abs/path.mjs\"")  ->  ("node /abs/path.mjs"), the suspected Node-loader error.
+
+Safety model (matches the user's requested workflow):
+  * DEFAULT = --dry-run: prints exactly what WOULD change, validates the resulting
+    JSON in memory, and WRITES NOTHING.
+  * --apply: makes a timestamped backup, writes, then re-reads and re-validates.
+
+Idempotent: re-running adds nothing once timeouts/fix are present.
+
+Usage:
+  python3 optimize-settings.py            # dry-run (default)
+  python3 optimize-settings.py --apply    # apply after you've reviewed the dry-run
+"""
+from __future__ import annotations
+import argparse
+import datetime as _dt
+import json
+import os
+import shutil
+import sys
+from copy import deepcopy
+
+SETTINGS = os.path.expanduser("~/.claude/settings.json")
+BACKUP_DIR = os.path.expanduser(
+    "~/Documents/GitHub/multi-agent-ralph-loop/.ralph/backups"
+)
+
+# Timeout policy (seconds) per hook event. Tight on hot/ blocking paths,
+# more generous on rare maintenance events that legitimately do more work.
+TIMEOUT_POLICY = {
+    "PreToolUse": 5,        # blocks the tool — must stay tight
+    "UserPromptSubmit": 5,  # blocks every message
+    "PostToolUse": 10,      # most are async already; sync ones get a ceiling
+    "Stop": 10,
+    "SessionStart": 10,
+    "SessionEnd": 15,       # vault writes
+    "PreCompact": 15,
+    "SubagentStart": 10,
+    "SubagentStop": 10,
+    "TeammateIdle": 10,
+    "TaskCompleted": 10,
+    "TaskCreated": 10,
+}
+DEFAULT_TIMEOUT = 10
+
+# The broken command (escaped quotes) and its robust replacement.
+MJS_ABS = os.path.expanduser("~/.claude/hooks/context-mode-cache-heal.mjs")
+MJS_BROKEN = f'"{MJS_ABS}"'          # value stored WITH literal quotes
+MJS_FIXED = f"node {MJS_ABS}"
+
+
+def canonical_hook(h: dict) -> dict:
+    """Return a hook dict with keys in a tidy, stable order."""
+    out = {}
+    for k in ("type", "command", "timeout", "async"):
+        if k in h:
+            out[k] = h[k]
+    for k in h:  # preserve any unexpected keys
+        if k not in out:
+            out[k] = h[k]
+    return out
+
+
+def short(cmd: str) -> str:
+    return cmd.replace('"', "").split("/")[-1].strip() or cmd
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true",
+                    help="write changes (default is dry-run)")
+    args = ap.parse_args()
+    dry = not args.apply
+
+    if not os.path.isfile(SETTINGS):
+        print(f"❌ settings.json not found at {SETTINGS}", file=sys.stderr)
+        return 1
+
+    with open(SETTINGS, encoding="utf-8") as f:
+        original_text = f.read()
+    try:
+        data = json.loads(original_text)
+    except json.JSONDecodeError as e:
+        print(f"❌ settings.json is not valid JSON: {e}", file=sys.stderr)
+        return 1
+
+    patched = deepcopy(data)
+    changes: list[str] = []
+    mjs_fixed = False
+    timeouts_added = 0
+    per_event: dict[str, int] = {}
+
+    for event, groups in patched.get("hooks", {}).items():
+        for group in groups:
+            new_hooks = []
+            for h in group.get("hooks", []):
+                # 1) .mjs quote fix
+                if h.get("command") == MJS_BROKEN:
+                    h["command"] = MJS_FIXED
+                    mjs_fixed = True
+                    changes.append(
+                        f"[{event}] FIX .mjs command: "
+                        f'"\\"...mjs\\"" -> "node ...mjs"'
+                    )
+                # 2) timeout backfill
+                if "timeout" not in h:
+                    t = TIMEOUT_POLICY.get(event, DEFAULT_TIMEOUT)
+                    h["timeout"] = t
+                    timeouts_added += 1
+                    per_event[event] = per_event.get(event, 0) + 1
+                new_hooks.append(canonical_hook(h))
+            group["hooks"] = new_hooks
+
+    # Validate the would-be result in memory.
+    new_text = json.dumps(patched, indent=2, ensure_ascii=False) + "\n"
+    try:
+        json.loads(new_text)
+    except json.JSONDecodeError as e:
+        print(f"❌ patched JSON failed validation (aborting): {e}", file=sys.stderr)
+        return 1
+
+    # Report
+    print("=" * 64)
+    print(f"  optimize-settings.py  [{'DRY-RUN' if dry else 'APPLY'}]")
+    print("=" * 64)
+    print(f"  Target: {SETTINGS}")
+    print(f"  .mjs command fix:   {'YES' if mjs_fixed else 'already correct / absent'}")
+    print(f"  timeouts added:     {timeouts_added}")
+    if per_event:
+        for ev in sorted(per_event):
+            print(f"      {ev:<18} +{per_event[ev]} (timeout={TIMEOUT_POLICY.get(ev, DEFAULT_TIMEOUT)}s)")
+    if not changes and timeouts_added == 0:
+        print("\n  ✅ Nothing to change — settings.json already hardened (idempotent).")
+        return 0
+    if mjs_fixed:
+        print(f"\n  .mjs before: \"{MJS_BROKEN}\"")
+        print(f"  .mjs after:  \"{MJS_FIXED}\"")
+
+    if dry:
+        print("\n  DRY-RUN: no file written. Review above, then re-run with --apply.")
+        return 0
+
+    # APPLY: backup -> write -> re-validate
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+    stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup = os.path.join(BACKUP_DIR, f"settings-{stamp}.json")
+    shutil.copy2(SETTINGS, backup)
+    print(f"\n  📦 backup: {backup}")
+
+    tmp = SETTINGS + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(new_text)
+    os.replace(tmp, SETTINGS)
+
+    # Re-read + re-validate from disk
+    with open(SETTINGS, encoding="utf-8") as f:
+        json.load(f)
+    print("  ✅ written and re-validated (valid JSON on disk).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hook-optimization/optimize-settings.py
+++ b/scripts/hook-optimization/optimize-settings.py
@@ -98,7 +98,12 @@ def main() -> int:
     timeouts_added = 0
     per_event: dict[str, int] = {}
 
-    for event, groups in patched.get("hooks", {}).items():
+    hooks_section = patched.get("hooks", {})
+    if not isinstance(hooks_section, dict):
+        print(f"❌ 'hooks' in settings.json is not a JSON object "
+              f"(got {type(hooks_section).__name__})", file=sys.stderr)
+        return 1
+    for event, groups in hooks_section.items():
         for group in groups:
             new_hooks = []
             for h in group.get("hooks", []):
@@ -149,20 +154,33 @@ def main() -> int:
         return 0
 
     # APPLY: backup -> write -> re-validate
-    os.makedirs(BACKUP_DIR, exist_ok=True)
-    stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    backup = os.path.join(BACKUP_DIR, f"settings-{stamp}.json")
-    shutil.copy2(SETTINGS, backup)
-    print(f"\n  📦 backup: {backup}")
+    try:
+        os.makedirs(BACKUP_DIR, exist_ok=True)
+        stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup = os.path.join(BACKUP_DIR, f"settings-{stamp}.json")
+        shutil.copy2(SETTINGS, backup)
+        print(f"\n  📦 backup: {backup}")
+    except OSError as e:
+        print(f"❌ backup failed ({e}) — aborting; settings.json unchanged", file=sys.stderr)
+        return 1
 
     tmp = SETTINGS + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        f.write(new_text)
-    os.replace(tmp, SETTINGS)
-
-    # Re-read + re-validate from disk
-    with open(SETTINGS, encoding="utf-8") as f:
-        json.load(f)
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(new_text)
+        os.replace(tmp, SETTINGS)
+        # Re-read + re-validate from disk
+        with open(SETTINGS, encoding="utf-8") as f:
+            json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        try:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        except OSError:
+            pass
+        print(f"❌ write/validate failed ({e}).\n   Restore with: cp {backup} {SETTINGS}",
+              file=sys.stderr)
+        return 1
     print("  ✅ written and re-validated (valid JSON on disk).")
     return 0
 

--- a/scripts/pre-commit-template.sh
+++ b/scripts/pre-commit-template.sh
@@ -57,7 +57,9 @@ if [[ -n "$STAGED_HOOKS" ]]; then
         hook_name=$(basename "$hook_file")
 
         # CRITICAL: "decision": "continue" is NEVER valid
-        if grep -qE '"decision":\s*"continue"' "$hook_file"; then
+        # v3.1.1: skip comment lines — a hook documenting the invalid form in a comment is
+        # not a violation; only active code matters.
+        if grep -vE '^[[:space:]]*#' "$hook_file" | grep -qE '"decision":\s*"continue"'; then
             echo -e "  ${RED}✗ $hook_name: Uses invalid {\"decision\": \"continue\"}${NC}"
             ((ERRORS++))
             continue

--- a/tests/HOOK_FORMAT_REFERENCE.md
+++ b/tests/HOOK_FORMAT_REFERENCE.md
@@ -11,14 +11,15 @@ Based on OFFICIAL Claude Code documentation from /anthropics/claude-code
 | UserPromptSubmit | `continue` | `true` / `false` (boolean) | `{"continue": true}` |
 | PreCompact | `continue` | `true` / `false` (boolean) | `{"continue": true}` |
 | SessionStart | `hookSpecificOutput` | object | `{"hookSpecificOutput": {"additionalContext": "..."}}` |
-| **Stop** | `decision` | `"approve"` / `"block"` (string) | `{"decision": "approve"}` |
+| **Stop** | `decision` (block only) | `"block"` or **clean exit** to allow | `{"decision": "block"}` / `exit 0` |
 
 ## CRITICAL RULES
 
 1. **The string `"continue"` is NEVER valid for the `decision` field**
    - WRONG: `{"decision": "continue"}` ❌
-   - RIGHT for Stop: `{"decision": "approve"}` ✅
-   - RIGHT for others: `{"continue": true}` ✅
+   - WRONG: `{"decision": "approve"}` ❌ (`"approve"` is NOT a valid Claude Code value)
+   - RIGHT for Stop: clean `exit 0` to allow, `{"decision": "block"}` to block ✅
+   - RIGHT for others: `{"continue": true}` or clean `exit 0` ✅
 
 2. **Stop hooks are the ONLY hooks that use `decision`**
    - All other hooks use `continue` (boolean)
@@ -33,7 +34,8 @@ Based on OFFICIAL Claude Code documentation from /anthropics/claude-code
 ```python
 def validate_hook_output(hook_type: str, output: dict) -> bool:
     if hook_type == "Stop":
-        return output.get("decision") in ("approve", "block")
+        # allow == clean exit (no output); block == {"decision": "block"}. "approve" is invalid.
+        return output == {} or output.get("decision") == "block"
     elif hook_type == "SessionStart":
         return "hookSpecificOutput" in output
     else:  # PostToolUse, PreToolUse, UserPromptSubmit, PreCompact

--- a/tests/hook-integration/test-hook-integration-v2.88.sh
+++ b/tests/hook-integration/test-hook-integration-v2.88.sh
@@ -88,11 +88,13 @@ test_ralph_subagent_stop() {
     RESULT=$(echo '{"subagentId": "test-subagent", "subagentType": "ralph-coder", "sessionId": "test-session"}' | \
         "$REPO_ROOT/.claude/hooks/ralph-subagent-stop.sh" 2>/dev/null || true)
 
-    if echo "$RESULT" | grep -q '"decision": "approve"'; then
+    # v3.1.1: completed subagent is ALLOWED via clean exit (exit 0, no output).
+    # {"decision":"approve"} is not a valid Claude Code format; allow == absence of block.
+    if ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
         pass
     else
         fail
-        echo -e "  ${RED}✗ Should approve when subagent completed${NC}"
+        echo -e "  ${RED}✗ Should allow (clean exit) when subagent completed${NC}"
     fi
 
     cleanup_test_state
@@ -258,7 +260,8 @@ test_session_isolation() {
     RESULT=$(echo '{"session_id": "test-session", "cwd": "/tmp", "stop_hook_active": false}' | \
         "$REPO_ROOT/.claude/hooks/ralph-stop-quality-gate.sh" 2>/dev/null || true)
 
-    if echo "$RESULT" | grep -q '"decision": "approve"'; then
+    # v3.1.1: no session => allow via clean exit (no block decision emitted).
+    if ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
         pass
     else
         fail
@@ -273,7 +276,9 @@ test_session_isolation() {
     RESULT=$(echo '{"session_id": "test-session", "cwd": "/tmp", "stop_hook_active": false}' | \
         "$REPO_ROOT/.claude/hooks/ralph-stop-quality-gate.sh" 2>/dev/null || true)
 
-    if echo "$RESULT" | grep -q "Stale session"; then
+    # v3.1.1: stale session is cleaned up silently (dir removed) + clean exit. Verify the
+    # cleanup itself, not the removed "Stale session" message.
+    if [[ ! -d "$STATE_DIR/test-session" ]]; then
         pass
     else
         fail
@@ -327,11 +332,11 @@ test_integration_flow() {
         RESULT=$(echo '{"subagentId": "flow-test", "subagentType": "ralph-coder", "sessionId": "test-session"}' | \
             "$REPO_ROOT/.claude/hooks/ralph-subagent-stop.sh" 2>/dev/null || true)
 
-        if echo "$RESULT" | grep -q '"decision": "approve"'; then
+        if ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
             pass
         else
             fail
-            echo -e "  ${RED}✗ SubagentStop did not approve completed subagent${NC}"
+            echo -e "  ${RED}✗ SubagentStop should allow (clean exit) completed subagent${NC}"
         fi
     fi
 

--- a/tests/hook-integration/test-hook-integration-v2.88.sh
+++ b/tests/hook-integration/test-hook-integration-v2.88.sh
@@ -86,11 +86,11 @@ test_ralph_subagent_stop() {
     echo '{"status": "completed", "task": "implement-auth"}' > "$STATE_DIR/test-session/subagents/test-subagent.json"
 
     RESULT=$(echo '{"subagentId": "test-subagent", "subagentType": "ralph-coder", "sessionId": "test-session"}' | \
-        "$REPO_ROOT/.claude/hooks/ralph-subagent-stop.sh" 2>/dev/null || true)
+        "$REPO_ROOT/.claude/hooks/ralph-subagent-stop.sh" 2>/dev/null); RC=$?
 
-    # v3.1.1: completed subagent is ALLOWED via clean exit (exit 0, no output).
-    # {"decision":"approve"} is not a valid Claude Code format; allow == absence of block.
-    if ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
+    # v3.1.1: completed subagent is ALLOWED via clean exit (RC 0) + no block JSON.
+    # {"decision":"approve"} is not a valid format. RC check (no `|| true`) catches a crash.
+    if [[ $RC -eq 0 ]] && ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
         pass
     else
         fail
@@ -258,10 +258,10 @@ test_session_isolation() {
     rm -rf "$STATE_DIR/test-session" 2>/dev/null || true
 
     RESULT=$(echo '{"session_id": "test-session", "cwd": "/tmp", "stop_hook_active": false}' | \
-        "$REPO_ROOT/.claude/hooks/ralph-stop-quality-gate.sh" 2>/dev/null || true)
+        "$REPO_ROOT/.claude/hooks/ralph-stop-quality-gate.sh" 2>/dev/null); RC=$?
 
-    # v3.1.1: no session => allow via clean exit (no block decision emitted).
-    if ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
+    # v3.1.1: no session => allow via clean exit (RC 0) + no block decision emitted.
+    if [[ $RC -eq 0 ]] && ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
         pass
     else
         fail
@@ -330,9 +330,9 @@ test_integration_flow() {
 
         # Stop subagent
         RESULT=$(echo '{"subagentId": "flow-test", "subagentType": "ralph-coder", "sessionId": "test-session"}' | \
-            "$REPO_ROOT/.claude/hooks/ralph-subagent-stop.sh" 2>/dev/null || true)
+            "$REPO_ROOT/.claude/hooks/ralph-subagent-stop.sh" 2>/dev/null); RC=$?
 
-        if ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
+        if [[ $RC -eq 0 ]] && ! echo "$RESULT" | grep -q '"decision":[[:space:]]*"block"'; then
             pass
         else
             fail

--- a/tests/test_hooks_optimization.py
+++ b/tests/test_hooks_optimization.py
@@ -1,0 +1,316 @@
+"""
+test_hooks_optimization.py — Validates the v3.1.1 hook performance + reliability
+improvements.
+
+Covers (per the user's request: "e2e + unit-test completo que validen todas las mejoras"):
+
+  UNIT (structural, hardware-independent — the robust regression guards):
+    * No active recursive `claude --print` anywhere (root cause of the 4.4s/message bug).
+    * project-state uses `find -L` (no per-symlink `-exec test`).
+    * The 3 SessionStart maintenance hooks carry the detached-fork guard.
+    * 100% of settings.json hooks have a `timeout`; values match the event policy.
+    * The .mjs SessionStart command is `node <path>` (no escaped-quote form).
+    * Every *.sh hook passes `bash -n`.
+
+  E2E / PERFORMANCE (marked slow — threshold = the user's 500ms bar, ~5x headroom):
+    * context-warning (every message) runs < 500ms.
+    * Each SessionStart hook runs < 500ms; forked maintenance hooks < 200ms.
+    * Full UserPromptSubmit chain runs < 500ms.
+    * optimize-settings.py is idempotent (dry-run reports nothing to change).
+    * validate-hooks.sh passes (JSON format, no regressions).
+
+Run:  pytest tests/test_hooks_optimization.py -v
+      pytest tests/test_hooks_optimization.py -v -m "not slow"   # skip timing
+"""
+from __future__ import annotations
+import json
+import os
+import re
+import subprocess
+import time
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Hooks whose performance/behavior this suite asserts on.
+PERF_FIXED_HOOKS = [
+    "context-warning.sh",
+    "project-state.sh",
+    "vault-graduation.sh",
+    "vault-promotion.sh",
+    "auto-sync-global.sh",
+]
+FORK_HOOKS = ["vault-graduation.sh", "vault-promotion.sh", "auto-sync-global.sh"]
+
+# Event → expected timeout (seconds), mirrors optimize-settings.py TIMEOUT_POLICY.
+TIMEOUT_POLICY = {
+    "PreToolUse": 5,
+    "UserPromptSubmit": 5,
+    "PostToolUse": 10,
+    "Stop": 10,
+    "SessionStart": 10,
+    "SessionEnd": 15,
+    "PreCompact": 15,
+    "SubagentStart": 10,
+    "SubagentStop": 10,
+    "TeammateIdle": 10,
+    "TaskCompleted": 10,
+    "TaskCreated": 10,
+}
+
+# Matches an *active* recursive Claude CLI invocation (the anti-pattern).
+_CLAUDE_CALL = re.compile(r"\bclaude\s+(--print|-p)\b")
+
+
+def _code_lines(path: str) -> list[tuple[int, str]]:
+    """Return (lineno, text) for non-blank, non-comment lines of a shell script."""
+    out = []
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for i, raw in enumerate(f, 1):
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            out.append((i, raw))
+    return out
+
+
+def _all_sh_hooks(hooks_dir: str) -> list[str]:
+    return sorted(
+        os.path.join(hooks_dir, f)
+        for f in os.listdir(hooks_dir)
+        if f.endswith(".sh") and os.path.isfile(os.path.join(hooks_dir, f))
+    )
+
+
+def _run_hook(path: str, payload: str, timeout: float = 8.0) -> tuple[float, int]:
+    """Run a hook with JSON payload on stdin. Return (elapsed_ms, returncode)."""
+    start = time.perf_counter()
+    proc = subprocess.run(
+        ["bash", path],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=PROJECT_ROOT,
+    )
+    return (time.perf_counter() - start) * 1000.0, proc.returncode
+
+
+def _best_ms(path: str, payload: str, runs: int = 2) -> float:
+    """Best-of-N elapsed ms (reduces noise from machine load)."""
+    return min(_run_hook(path, payload)[0] for _ in range(runs))
+
+
+def _event_hook_paths(event: str) -> list[str]:
+    """Resolved .sh hook paths registered for a given event in settings.json."""
+    settings = os.path.expanduser("~/.claude/settings.json")
+    try:
+        data = json.load(open(settings, encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    paths = []
+    for group in data.get("hooks", {}).get(event, []):
+        for h in group.get("hooks", []):
+            first = h.get("command", "").split()[0] if h.get("command") else ""
+            if first.endswith(".sh") and os.path.isfile(first):
+                paths.append(first)
+    return paths
+
+
+# Collected at import time so they can parametrize per-hook timing tests.
+_UPS_HOOKS = _event_hook_paths("UserPromptSubmit")
+_STOP_HOOKS = _event_hook_paths("Stop")
+
+
+# ---------------------------------------------------------------------------
+# UNIT — anti-pattern regression guards (fast, hardware-independent)
+# ---------------------------------------------------------------------------
+
+class TestNoRecursiveClaude:
+    """The recursive `claude --print "/context"` subprocess caused the 4.4s/message
+    bug. No hook may reintroduce it in active code."""
+
+    def test_no_recursive_claude_in_any_hook(self, hooks_dir):
+        violations = []
+        for path in _all_sh_hooks(hooks_dir):
+            for lineno, line in _code_lines(path):
+                if _CLAUDE_CALL.search(line):
+                    violations.append(f"{os.path.basename(path)}:{lineno}: {line.strip()}")
+        assert not violations, (
+            "Active recursive `claude --print` found (perf landmine):\n"
+            + "\n".join(violations)
+        )
+
+    @pytest.mark.parametrize("hook", ["context-warning.sh", "project-state.sh"])
+    def test_specific_hooks_clean(self, hooks_dir, hook):
+        path = os.path.join(hooks_dir, hook)
+        bad = [f"{ln}: {t.strip()}" for ln, t in _code_lines(path) if _CLAUDE_CALL.search(t)]
+        assert not bad, f"{hook} still calls claude recursively:\n" + "\n".join(bad)
+
+
+class TestProjectStateFindOptimization:
+    def test_uses_find_dash_L(self, hooks_dir):
+        text = open(os.path.join(hooks_dir, "project-state.sh"), encoding="utf-8").read()
+        assert "find -L" in text, "project-state.sh should use `find -L` for broken symlinks"
+
+    def test_no_per_symlink_exec_test(self, hooks_dir):
+        for lineno, line in _code_lines(os.path.join(hooks_dir, "project-state.sh")):
+            assert "-exec test -e" not in line, (
+                f"project-state.sh:{lineno} still spawns a `test` per symlink (slow)"
+            )
+
+
+class TestForkGuards:
+    """The 3 SessionStart maintenance hooks must self-relaunch detached."""
+
+    @pytest.mark.parametrize("hook", FORK_HOOKS)
+    def test_has_background_fork_guard(self, hooks_dir, hook):
+        text = open(os.path.join(hooks_dir, hook), encoding="utf-8").read()
+        assert "RALPH_HOOK_BG" in text, f"{hook} missing the detached-fork guard"
+        assert "nohup bash" in text and "&" in text, f"{hook} fork guard incomplete"
+
+
+# ---------------------------------------------------------------------------
+# UNIT — settings.json hardening
+# ---------------------------------------------------------------------------
+
+class TestSettingsHardening:
+    def test_settings_valid_json(self, load_settings_json):
+        assert load_settings_json(), "settings.json must load as valid JSON"
+
+    def test_all_hooks_have_timeout(self, load_settings_json):
+        data = load_settings_json()
+        missing = []
+        for event, groups in data.get("hooks", {}).items():
+            for group in groups:
+                for h in group.get("hooks", []):
+                    if "timeout" not in h:
+                        missing.append(f"{event}: {h.get('command','?')}")
+        assert not missing, "Hooks without timeout (60s-hang risk):\n" + "\n".join(missing)
+
+    def test_timeout_values_match_policy(self, load_settings_json):
+        data = load_settings_json()
+        wrong = []
+        for event, groups in data.get("hooks", {}).items():
+            expected = TIMEOUT_POLICY.get(event)
+            if expected is None:
+                continue
+            for group in groups:
+                for h in group.get("hooks", []):
+                    t = h.get("timeout")
+                    # Pre-existing larger timeouts (e.g. 30/60 on async hooks) are allowed.
+                    if t is not None and t < expected:
+                        wrong.append(f"{event}: timeout={t} < policy {expected}")
+        assert not wrong, "Timeouts below policy:\n" + "\n".join(wrong)
+
+    def test_mjs_command_fixed(self, load_settings_json):
+        data = load_settings_json()
+        commands = [
+            h.get("command", "")
+            for groups in data.get("hooks", {}).values()
+            for group in groups
+            for h in group.get("hooks", [])
+        ]
+        mjs = [c for c in commands if "context-mode-cache-heal.mjs" in c]
+        assert mjs, "expected the .mjs SessionStart hook to be present"
+        for c in mjs:
+            assert c.startswith("node "), f".mjs command not normalized to `node <path>`: {c}"
+            assert '"' not in c, f".mjs command still contains quotes: {c}"
+
+
+# ---------------------------------------------------------------------------
+# UNIT — syntax
+# ---------------------------------------------------------------------------
+
+class TestSyntax:
+    def test_all_hooks_bash_n_clean(self, hooks_dir):
+        errors = []
+        for path in _all_sh_hooks(hooks_dir):
+            proc = subprocess.run(["bash", "-n", path], capture_output=True, text=True)
+            if proc.returncode != 0:
+                errors.append(f"{os.path.basename(path)}: {proc.stderr.strip()}")
+        assert not errors, "bash -n failures:\n" + "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# E2E / PERFORMANCE — timing (slow). Threshold = user's 500ms bar (~5x headroom).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestPerformance:
+    THRESHOLD_MS = 500
+    FORK_THRESHOLD_MS = 200
+
+    def test_context_warning_under_threshold(self, hooks_dir):
+        ms = _best_ms(os.path.join(hooks_dir, "context-warning.sh"), '{"prompt":"test"}')
+        assert ms < self.THRESHOLD_MS, f"context-warning.sh took {ms:.0f}ms (>= {self.THRESHOLD_MS})"
+
+    @pytest.mark.parametrize("hook", PERF_FIXED_HOOKS)
+    def test_perf_fixed_hooks_under_threshold(self, hooks_dir, hook):
+        payload = '{"hook_event_name":"SessionStart","source":"startup","prompt":"t"}'
+        ms = _best_ms(os.path.join(hooks_dir, hook), payload)
+        assert ms < self.THRESHOLD_MS, f"{hook} took {ms:.0f}ms (>= {self.THRESHOLD_MS})"
+
+    @pytest.mark.parametrize("hook", FORK_HOOKS)
+    def test_fork_hooks_return_fast(self, hooks_dir, hook):
+        ms = _best_ms(os.path.join(hooks_dir, hook), '{"hook_event_name":"SessionStart"}')
+        assert ms < self.FORK_THRESHOLD_MS, (
+            f"{hook} returned in {ms:.0f}ms (>= {self.FORK_THRESHOLD_MS}); fork not effective"
+        )
+
+    @pytest.mark.parametrize(
+        "hook_path", _UPS_HOOKS, ids=[os.path.basename(p) for p in _UPS_HOOKS] or ["none"]
+    )
+    def test_each_userpromptsubmit_hook_under_threshold(self, hook_path):
+        """Each UserPromptSubmit hook (runs on every message) must clear the 500ms bar.
+        Per-hook + best-of-3 = stable and pinpoints exactly which hook regressed, instead
+        of a flaky aggregate sum over stateful, load-sensitive hooks."""
+        if not _UPS_HOOKS:
+            pytest.skip("no UserPromptSubmit hooks resolved from settings.json")
+        ms = _best_ms(hook_path, '{"prompt":"test"}', runs=3)
+        assert ms < self.THRESHOLD_MS, (
+            f"{os.path.basename(hook_path)} took {ms:.0f}ms (>= {self.THRESHOLD_MS}); "
+            "likely a reintroduced slow subprocess (e.g. recursive `claude`)."
+        )
+
+    @pytest.mark.parametrize(
+        "hook_path", _STOP_HOOKS, ids=[os.path.basename(p) for p in _STOP_HOOKS] or ["none"]
+    )
+    def test_each_stop_hook_under_threshold(self, hook_path):
+        """Each Stop hook (runs at every turn end) must clear the 500ms bar."""
+        if not _STOP_HOOKS:
+            pytest.skip("no Stop hooks resolved from settings.json")
+        ms = _best_ms(hook_path, "{}", runs=3)
+        assert ms < self.THRESHOLD_MS, (
+            f"{os.path.basename(hook_path)} took {ms:.0f}ms (>= {self.THRESHOLD_MS})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# E2E — idempotency & no-regression
+# ---------------------------------------------------------------------------
+
+class TestIdempotencyAndRegression:
+    def test_optimize_settings_idempotent(self, project_root):
+        script = os.path.join(project_root, "scripts", "hook-optimization", "optimize-settings.py")
+        if not os.path.isfile(script):
+            pytest.skip("optimize-settings.py not present")
+        proc = subprocess.run(["python3", script], capture_output=True, text=True, timeout=30)
+        assert proc.returncode == 0, f"dry-run failed: {proc.stderr}"
+        assert "Nothing to change" in proc.stdout, (
+            "settings.json not fully hardened (optimize-settings found pending changes):\n"
+            + proc.stdout
+        )
+
+    @pytest.mark.slow
+    def test_validate_hooks_passes(self, project_root):
+        script = os.path.join(project_root, "validate-hooks.sh")
+        if not os.path.isfile(script):
+            pytest.skip("validate-hooks.sh not present")
+        proc = subprocess.run(["bash", script], capture_output=True, text=True, timeout=120)
+        assert proc.returncode == 0, f"validate-hooks.sh failed:\n{proc.stdout}\n{proc.stderr}"

--- a/tests/test_hooks_optimization.py
+++ b/tests/test_hooks_optimization.py
@@ -110,7 +110,8 @@ def _event_hook_paths(event: str) -> list[str]:
     """Resolved .sh hook paths registered for a given event in settings.json."""
     settings = os.path.expanduser("~/.claude/settings.json")
     try:
-        data = json.load(open(settings, encoding="utf-8"))
+        with open(settings, encoding="utf-8") as fh:
+            data = json.load(fh)
     except (OSError, json.JSONDecodeError):
         return []
     paths = []
@@ -181,10 +182,18 @@ class TestForkGuards:
 
 class TestSettingsHardening:
     def test_settings_valid_json(self, load_settings_json):
-        assert load_settings_json(), "settings.json must load as valid JSON"
+        data = load_settings_json()  # call the factory fixture, don't assert the callable
+        assert isinstance(data, dict) and data, "settings.json must be a non-empty JSON object"
+
+    def test_event_hooks_resolved_for_timing(self):
+        # Guard: the parametrized per-hook timing tests generate ZERO cases (silently) if
+        # these import-time lists are empty. This sentinel fails loudly instead.
+        assert _UPS_HOOKS, "No UserPromptSubmit hooks resolved from settings.json"
+        assert _STOP_HOOKS, "No Stop hooks resolved from settings.json"
 
     def test_all_hooks_have_timeout(self, load_settings_json):
         data = load_settings_json()
+        assert data, "settings.json not found/empty — cannot validate timeouts"
         missing = []
         for event, groups in data.get("hooks", {}).items():
             for group in groups:

--- a/validate-hooks.sh
+++ b/validate-hooks.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-hooks-v2.sh — Valida hooks de Claude Code contra la API actual
+# Detecta: JSON invalido, campos inexistentes, sintaxis rota, umask faltante
+
+HOOKS_DIR="${1:-.claude/hooks}"
+EXIT_CODE=0
+ISSUES=0
+
+echo "🔍 Validando hooks en: $HOOKS_DIR"
+echo "================================"
+
+# 1. Patrones JSON invalidos en CODIGO ACTIVO (excluye comentarios)
+echo ""
+echo "[1] Patrones JSON invalidos en codigo activo..."
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file=$(echo "$line" | cut -d: -f1)
+  lineno=$(echo "$line" | cut -d: -f2)
+  content=$(echo "$line" | cut -d: -f3-)
+  # Skip if line is a comment or already FIXED
+  if echo "$content" | grep -qE '^\s*#' ; then continue; fi
+  if echo "$content" | grep -q 'FIXED'; then continue; fi
+  echo "  ❌ $(basename "$file"):$lineno → $content"
+  EXIT_CODE=1; ISSUES=$((ISSUES+1))
+done < <(grep -rn '"decision"[[:space:]]*:[[:space:]]*"approve"' "$HOOKS_DIR"/*.sh "$HOOKS_DIR"/*.py "$HOOKS_DIR"/*.js 2>/dev/null || true)
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file=$(echo "$line" | cut -d: -f1)
+  lineno=$(echo "$line" | cut -d: -f2)
+  content=$(echo "$line" | cut -d: -f3-)
+  if echo "$content" | grep -qE '^\s*#' ; then continue; fi
+  if echo "$content" | grep -q 'FIXED'; then continue; fi
+  echo "  ❌ $(basename "$file"):$lineno → campo 'decision: continue' invalido"
+  EXIT_CODE=1; ISSUES=$((ISSUES+1))
+done < <(grep -rn '"decision"[[:space:]]*:[[:space:]]*"continue"' "$HOOKS_DIR"/*.sh 2>/dev/null || true)
+
+# 2. Campos JSON inexistentes (feedback, cleanup en outputs con decision)
+echo ""
+echo "[2] Campos JSON inexistentes..."
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file=$(echo "$line" | cut -d: -f1)
+  lineno=$(echo "$line" | cut -d: -f2)
+  content=$(echo "$line" | cut -d: -f3-)
+  if echo "$content" | grep -qE '^\s*#' ; then continue; fi
+  if echo "$content" | grep -q 'FIXED'; then continue; fi
+  # Only flag if in an echo/printf context (actual JSON output)
+  if echo "$content" | grep -qE '(echo|printf)'; then
+    echo "  ❌ $(basename "$file"):$lineno → campo 'feedback' invalido en JSON output"
+    EXIT_CODE=1; ISSUES=$((ISSUES+1))
+  fi
+done < <(grep -rn '"feedback"' "$HOOKS_DIR"/*.sh 2>/dev/null | grep 'decision' || true)
+
+# 3. Sintaxis bash
+echo ""
+echo "[3] Verificando sintaxis..."
+for f in "$HOOKS_DIR"/*.sh; do
+  [ -f "$f" ] || continue
+  if ! bash -n "$f" 2>/dev/null; then
+    echo "  ❌ Sintaxis: $(basename "$f")"
+    EXIT_CODE=1; ISSUES=$((ISSUES+1))
+  fi
+  [ -x "$f" ] || echo "  ⚠️  No ejecutable: $(basename "$f")"
+done
+
+# 4. umask 077 (defense in depth)
+echo ""
+echo "[4] Verificando umask 077..."
+for f in "$HOOKS_DIR"/*.sh; do
+  [ -f "$f" ] || continue
+  grep -q 'umask 077' "$f" 2>/dev/null || echo "  ⚠️  Falta umask 077: $(basename "$f")"
+done
+
+# Resumen
+echo ""
+echo "================================"
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "✅ Validacion pasada. $ISSUES problemas criticos."
+else
+  echo "❌ $ISSUES problemas encontrados."
+  echo "   Ejecuta: bash fix-hook-formats.sh $HOOKS_DIR"
+fi
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

Performance + reliability overhaul of the hook system. Eliminates the latency and hang
risks that were slowing down **every** Claude interaction, hardens reliability, and adds a
comprehensive test suite. All measured, all validated.

## Performance (measured, best-of-3)

| Hook | Event | Before | After | Δ |
|------|-------|-------:|------:|---|
| `context-warning` | UserPromptSubmit (every message) | 4388ms | 101ms | **−97.7%** |
| `periodic-reminder` | UserPromptSubmit | could block ∞ (no timeout) | 35ms | fixed |
| `project-state` | SessionStart | 2074ms | 138ms | −93.3% |
| `vault-graduation` | SessionStart | 2033ms | 28ms | −98.6% |
| `vault-promotion` | SessionStart | 718ms | 28ms | −96.1% |
| `auto-sync-global` | SessionStart | 622ms | 27ms | −95.7% |

**Net: per-message hook latency ~4.7s → ~0.4s; startup ~6.6s → ~1.3s.**

### Root causes fixed
- **Recursive `claude --print "/context"` subprocess** in 3 hooks (context-warning,
  project-state, periodic-reminder). A CLI-calls-CLI anti-pattern: cold-start + 3s timeout
  cap, on every message. `periodic-reminder` had no timeout and could block indefinitely.
  Replaced with the transcript/message-count estimators these hooks already had.
- **Synchronous full-vault scans** at SessionStart. The 3 maintenance hooks now self-relaunch
  detached (`nohup &`) and return in ~28ms; the scan runs in the background.
- **`find ... -exec test -e` per symlink** in project-state → `find -L` (no per-symlink process).

## Reliability

- **Timeouts on 77/77 hooks** (was 2/77) via `scripts/hook-optimization/optimize-settings.py`
  — an idempotent, **dry-run-first** patcher for `~/.claude/settings.json`. A hung hook now
  degrades to a bounded 5–15s wait instead of Claude Code's 60s default.
- **`.mjs` SessionStart command** normalized from the escaped-double-quote form to
  `node <path>` (the suspected Node `cjs/loader` error source).
- **44 format-correctness fixes** across hooks (invalid `{"decision":"approve"}` → clean exit),
  per `docs/hooks/AUDIT-REPORT.md`.

## Tests

- **`tests/test_hooks_optimization.py` — 38 tests**: structural anti-pattern guards
  (no recursive `claude`, `find -L`, fork guards, 100% timeouts, `.mjs`, syntax) + per-hook
  timing (500ms bar, best-of-3) + idempotency + `validate-hooks.sh`. The structural
  no-recursive-claude guard **caught a 3rd instance** (periodic-reminder) that manual review
  missed.
- **Pre-commit consistency fixes**: the Phase-1 validator now skips comment lines (a hook
  *documenting* the invalid form in a comment is no longer a false positive); the
  hook-integration tests were updated to the corrected clean-exit contract (the removed
  `{"decision":"approve"}` is not valid Claude Code output). Integration suite: **15/15**.

## Safety

- Every modified hook backed up under `.ralph/backups/` (rollback available).
- `optimize-settings.py` ran dry-run → validate → apply → re-validate; idempotent.
- Pre-commit gate: ✓ All validations passed.

## Deferred (documented)

Hook **consolidation** (merging the Agent|Task injector chain into a dispatcher) is documented
in `docs/hooks/CONSOLIDATION-MAP.md` and intentionally deferred: warm chains already run
~25ms, so the dispatcher's latency upside is marginal while its risk (a confirmed `$PLAN_STATE`
race if parallelized, stateful guards, deny-merge semantics) is real. To be done as a separate,
test-guarded effort.

## Post-merge validation checklist

- [ ] `bash validate-hooks.sh` → 0 critical
- [ ] `pytest tests/test_hooks_optimization.py` → 38 passed
- [ ] `python3 scripts/hook-optimization/optimize-settings.py` (dry-run) → "Nothing to change"
- [ ] `~/.claude/settings.json` → 77/77 hooks have `timeout`, `.mjs` = `node <path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
