### PR TITLE
fix(hooks): codex review follow-ups (breadcrumb + drop futile .mjs fix)

### DIFF
--- a/.claude/hooks/auto-sync-global.sh
+++ b/.claude/hooks/auto-sync-global.sh
@@ -13,6 +13,9 @@ if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
     mkdir -p "${HOME}/.ralph/logs" 2>/dev/null || true
     RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >>"${HOME}/.ralph/logs/auto-sync-global.bg.log" 2>&1 &
     disown 2>/dev/null || true
+    # Breadcrumb (codex review): keep a SessionStart context line; real sync status now
+    # goes to the bg log instead of being injected synchronously.
+    printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"auto-sync-global: maintenance running in background"}}'
     exit 0
 fi
 

--- a/.claude/hooks/vault-graduation.sh
+++ b/.claude/hooks/vault-graduation.sh
@@ -17,6 +17,9 @@ if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
     mkdir -p "${HOME}/.ralph/logs" 2>/dev/null || true
     RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >>"${HOME}/.ralph/logs/vault-graduation.bg.log" 2>&1 &
     disown 2>/dev/null || true
+    # Breadcrumb (codex review): keep a SessionStart context line even though the real
+    # graduation status now goes to the bg log instead of being injected synchronously.
+    printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"vault-graduation: maintenance running in background"}}'
     exit 0
 fi
 

--- a/.claude/hooks/vault-promotion.sh
+++ b/.claude/hooks/vault-promotion.sh
@@ -31,6 +31,9 @@ if [[ "${RALPH_HOOK_BG:-0}" != "1" ]]; then
     mkdir -p "${HOME}/.ralph/logs" 2>/dev/null || true
     RALPH_HOOK_BG=1 nohup bash "$0" </dev/null >>"${HOME}/.ralph/logs/vault-promotion.bg.log" 2>&1 &
     disown 2>/dev/null || true
+    # Breadcrumb (codex review): keep a SessionStart context line; real promotion status
+    # now goes to the bg log instead of being injected synchronously.
+    printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"vault-promotion: maintenance running in background"}}'
     exit 0
 fi
 

--- a/scripts/hook-optimization/optimize-settings.py
+++ b/scripts/hook-optimization/optimize-settings.py
@@ -5,8 +5,11 @@ optimize-settings.py — Safe, idempotent hardener for ~/.claude/settings.json h
 What it does (mechanical, low-risk):
   1. Adds an event-appropriate `timeout` (seconds) to every hook entry that lacks one,
      so a hung hook degrades to a bounded wait instead of Claude Code's 60s default.
-  2. Fixes the fragile escaped-double-quote `.mjs` SessionStart command
-     ("\"/abs/path.mjs\"")  ->  ("node /abs/path.mjs"), the suspected Node-loader error.
+
+  (An earlier version also "normalized" the context-mode `.mjs` command, but that hook
+   entry is owned by the context-mode plugin — it re-registers the quoted form every
+   session, and that quoted path executes fine — so normalizing it was futile churn and
+   has been removed. Only the timeout backfill is durable here.)
 
 Safety model (matches the user's requested workflow):
   * DEFAULT = --dry-run: prints exactly what WOULD change, validates the resulting
@@ -51,11 +54,6 @@ TIMEOUT_POLICY = {
 }
 DEFAULT_TIMEOUT = 10
 
-# The broken command (escaped quotes) and its robust replacement.
-MJS_ABS = os.path.expanduser("~/.claude/hooks/context-mode-cache-heal.mjs")
-MJS_BROKEN = f'"{MJS_ABS}"'          # value stored WITH literal quotes
-MJS_FIXED = f"node {MJS_ABS}"
-
 
 def canonical_hook(h: dict) -> dict:
     """Return a hook dict with keys in a tidy, stable order."""
@@ -93,8 +91,6 @@ def main() -> int:
         return 1
 
     patched = deepcopy(data)
-    changes: list[str] = []
-    mjs_fixed = False
     timeouts_added = 0
     per_event: dict[str, int] = {}
 
@@ -107,15 +103,7 @@ def main() -> int:
         for group in groups:
             new_hooks = []
             for h in group.get("hooks", []):
-                # 1) .mjs quote fix
-                if h.get("command") == MJS_BROKEN:
-                    h["command"] = MJS_FIXED
-                    mjs_fixed = True
-                    changes.append(
-                        f"[{event}] FIX .mjs command: "
-                        f'"\\"...mjs\\"" -> "node ...mjs"'
-                    )
-                # 2) timeout backfill
+                # timeout backfill (the only durable, non-plugin-owned change)
                 if "timeout" not in h:
                     t = TIMEOUT_POLICY.get(event, DEFAULT_TIMEOUT)
                     h["timeout"] = t
@@ -137,17 +125,13 @@ def main() -> int:
     print(f"  optimize-settings.py  [{'DRY-RUN' if dry else 'APPLY'}]")
     print("=" * 64)
     print(f"  Target: {SETTINGS}")
-    print(f"  .mjs command fix:   {'YES' if mjs_fixed else 'already correct / absent'}")
     print(f"  timeouts added:     {timeouts_added}")
     if per_event:
         for ev in sorted(per_event):
             print(f"      {ev:<18} +{per_event[ev]} (timeout={TIMEOUT_POLICY.get(ev, DEFAULT_TIMEOUT)}s)")
-    if not changes and timeouts_added == 0:
+    if timeouts_added == 0:
         print("\n  ✅ Nothing to change — settings.json already hardened (idempotent).")
         return 0
-    if mjs_fixed:
-        print(f"\n  .mjs before: \"{MJS_BROKEN}\"")
-        print(f"  .mjs after:  \"{MJS_FIXED}\"")
 
     if dry:
         print("\n  DRY-RUN: no file written. Review above, then re-run with --apply.")

--- a/tests/test_hooks_optimization.py
+++ b/tests/test_hooks_optimization.py
@@ -147,7 +147,7 @@ class TestNoRecursiveClaude:
             + "\n".join(violations)
         )
 
-    @pytest.mark.parametrize("hook", ["context-warning.sh", "project-state.sh"])
+    @pytest.mark.parametrize("hook", ["context-warning.sh", "project-state.sh", "periodic-reminder.sh"])
     def test_specific_hooks_clean(self, hooks_dir, hook):
         path = os.path.join(hooks_dir, hook)
         bad = [f"{ln}: {t.strip()}" for ln, t in _code_lines(path) if _CLAUDE_CALL.search(t)]
@@ -217,19 +217,20 @@ class TestSettingsHardening:
                         wrong.append(f"{event}: timeout={t} < policy {expected}")
         assert not wrong, "Timeouts below policy:\n" + "\n".join(wrong)
 
-    def test_mjs_command_fixed(self, load_settings_json):
+    def test_mjs_hook_present_and_timed(self, load_settings_json):
+        # The context-mode .mjs hook entry is PLUGIN-OWNED: context-mode re-registers it
+        # every session in a quoted form (`"/abs/path.mjs"`) that executes fine (the shell
+        # strips the quotes). We do NOT assert its command form — that would fight the
+        # plugin. We only assert our durable contribution survived: the timeout.
         data = load_settings_json()
-        commands = [
-            h.get("command", "")
-            for groups in data.get("hooks", {}).values()
-            for group in groups
-            for h in group.get("hooks", [])
-        ]
-        mjs = [c for c in commands if "context-mode-cache-heal.mjs" in c]
-        assert mjs, "expected the .mjs SessionStart hook to be present"
-        for c in mjs:
-            assert c.startswith("node "), f".mjs command not normalized to `node <path>`: {c}"
-            assert '"' not in c, f".mjs command still contains quotes: {c}"
+        assert data, "settings.json not found/empty"
+        for groups in data.get("hooks", {}).values():
+            for group in groups:
+                for h in group.get("hooks", []):
+                    if "context-mode-cache-heal.mjs" in h.get("command", ""):
+                        assert "timeout" in h, ".mjs hook should still carry a timeout"
+                        return
+        # Absent is acceptable (plugin may be disabled) — do not fail.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Applies codex-reviewer follow-ups (verdict: SHIP). Restores SessionStart breadcrumbs for the 3 detached fork hooks; adds periodic-reminder to the no-recursive-claude test list; **removes the .mjs normalization** (over-reach: the quoted form executes fine and is plugin-owned/reverts — empirically verified). Keeps durable timeout hardening. Validation: 16/16 deterministic, integration 15/15, validate-hooks 0 critical, optimize-settings idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)