### PR TITLE
chore(agents): integrate ralph-frontend v3.0.1 (model-agnostic)

### DIFF
--- a/.claude/agents/ralph-frontend.md
+++ b/.claude/agents/ralph-frontend.md
@@ -1,6 +1,8 @@
 ---
-# VERSION: 3.0.0
-model: default
+# VERSION: 3.0.1
+# Model: inherits from parent session (model-agnostic).
+# Override at spawn time via Task({ model: "sonnet" | "opus" | "haiku" })
+# if a specific tier is needed.
 name: ralph-frontend
 description: |
   Frontend specialist teammate for Agent Teams. Loads DESIGN.md for design consistency, enforces WCAG 2.1 AA, tests 8 component states. Use when implementing frontend features, UI components, or visual elements.


### PR DESCRIPTION
Integrates the pending ralph-frontend.md change (was sitting uncommitted, pre-existing). Removes hardcoded `model: default` → parent-inheritance + spawn-time override docs. Validated: YAML frontmatter valid, name/description intact, model-agnostic (pre-commit Phase 7 ✓). Only the frontmatter block changed (+4/-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)