### PR TITLE
chore(hooks): bump ralph-* hook versions for v3.1.1 format fixes

### DIFF
--- a/.claude/hooks/ralph-stop-quality-gate.sh
+++ b/.claude/hooks/ralph-stop-quality-gate.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 umask 077
 # ralph-stop-quality-gate.sh - Quality gate for Stop event
-# VERSION: 2.88.0
+# VERSION: 2.88.1
+# v2.88.1 (v3.1.1): format-correctness — removed invalid {"decision":"approve"}; allow is
+#                   signaled by clean exit 0. Stale-session cleanup verified by
+#                   tests/hook-integration/test-hook-integration-v2.88.sh.
 # REPO: multi-agent-ralph-loop
 #
 # Triggered by: Stop hook event

--- a/.claude/hooks/ralph-subagent-start.sh
+++ b/.claude/hooks/ralph-subagent-start.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 umask 077
 # ralph-subagent-start.sh - Initialize subagents with Ralph context, memory, and integration
-# VERSION: 2.95.0
+# VERSION: 2.95.1
+# v2.95.1 (v3.1.1): format-correctness — removed invalid {"decision":"approve"} (allow is
+#                   signaled by clean exit 0). Verified by tests/hook-integration.
 # REPO: multi-agent-ralph-loop
 #
 # Triggered by: SubagentStart hook event (matcher: ralph-*)

--- a/.claude/hooks/ralph-subagent-stop.sh
+++ b/.claude/hooks/ralph-subagent-stop.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 umask 077
 # ralph-subagent-stop.sh - Quality gate for ralph-* subagent termination
-# VERSION: 2.95.0
+# VERSION: 2.95.1
+# v2.95.1 (v3.1.1): format-correctness — removed invalid {"decision":"approve"}; a
+#                   completed subagent is allowed via clean exit 0. Verified by the
+#                   tightened tests/hook-integration assertions (RC==0 + no block).
 # Event: SubagentStop
 # Matcher: ralph-*
 #


### PR DESCRIPTION
Version hygiene: the 3 ralph-* hooks changed by the v3.1.1 format-correctness fixes (#22) get a patch bump in their own lineage + changelog note (2.88.0→2.88.1, 2.95.0→2.95.1). No logic change. ralph-frontend.md already at 3.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)