### PR TITLE
fix(skills): restore Aristotle Integration regression from #26

### DIFF
--- a/.claude/skills/adversarial/SKILL.md
+++ b/.claude/skills/adversarial/SKILL.md
@@ -23,7 +23,15 @@ Use when the user says `adversarial`, `analisis opuesto`, `opposing analysis`, `
 5. Separate proven issues from plausible risks.
 6. Recommend one concrete next action: keep, adjust, defer, validate, or revert.
 
-For non-trivial work, apply a compact Aristotle pass: assumption autopsy, irreducible truths, reconstruction from evidence, assumption-vs-truth map, and the smallest risk-reducing next move.
+## Aristotle Integration
+
+For non-trivial work, run a compact Aristotle First Principles pass — the same five phases the orchestrator uses — turned toward the opposing position:
+
+1. **Assumption Autopsy** — list every assumption the claim or plan depends on.
+2. **Irreducible Truths** — strip the assumptions; keep only what survives in the current repo/runtime.
+3. **Reconstruction from Zero** — rebuild the strongest counter-position from those truths alone.
+4. **Assumption vs Truth Map** — separate what is proven from what is merely assumed.
+5. **The Aristotelian Move** — the single highest-leverage next action: keep, adjust, defer, validate, or revert.
 
 ## External Advisor Mode
 


### PR DESCRIPTION
## Problem

PR #26's rewrite of the `adversarial` skill dropped the explicit **Aristotle Integration** section, regressing two tests:

- `tests/test_v3_integration.py::TestAdversarialReferences::test_has_aristotle_integration_section`
- `tests/test_v3_integration.py::TestAdversarialReferences::test_references_assumption_autopsy`

These failures were **masked in CI** by a `|| true` on the `pytest tests/` step (`.github/workflows/ci.yml:93`), so the regression merged to `main` silently. It also violates the non-negotiable *"preserve Aristotle + 5 phases"* project principle.

## Fix

Restore a dedicated `## Aristotle Integration` section listing the five canonical phases (Assumption Autopsy, Irreducible Truths, Reconstruction, Assumption vs Truth Map, Aristotelian Move), framed for opposite-analysis.

## Verification

`pytest tests/test_v3_integration.py::TestAdversarialReferences` → 2 passed.

> The `|| true` masking that hid this is addressed in a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)