### PR TITLE
feat(distribution): Claude-native agents/skills as COPIES with parity gate

### DIFF
--- a/docs/architecture/DISTRIBUTION_POLICY.md
+++ b/docs/architecture/DISTRIBUTION_POLICY.md
@@ -14,8 +14,8 @@ This document defines the definitive distribution strategy for Ralph infrastruct
 |-----------|----------|---------------|
 | Rules (~/.claude/rules/) | **COPY** | Must work without repo. Checksum-validated for drift detection. |
 | Universal Hooks (~/.claude/hooks/) | **COPY** | Must work without repo. Registered in settings.json with absolute paths. |
-| Agent Definitions (~/.claude/agents/) | **SYMLINK** | Tied to repo by design. Acceptable breakage if repo moves. |
-| Skills (~/.claude/skills/) | **MIXED** | Key skills copied (task-classifier, curator), others symlinked. |
+| Agent Definitions (~/.claude/agents/) | **SYMLINK**, except the Claude-native set → **COPY** | Symlinked by design. EXCEPTION: the Codex→Claude review/bug agents are COPIED (see below) so a stale/moved repo checkout cannot resurrect their old Codex-dependent version. |
+| Skills (~/.claude/skills/) | **MIXED** | Key skills copied (task-classifier, curator); the Codex→Claude `bugs`/`security` skills are COPIED (see below); others symlinked. |
 | Layer Files (~/.ralph/layers/) | **COPY** | Must work without repo. Updated by wake-up hook. |
 | Settings.json | **SINGLE** | ~/.claude/settings.json is the ONLY config. All models use this. |
 
@@ -57,6 +57,34 @@ Skills are distributed to 6 platform directories:
 
 Key skills (task-classifier, curator, orchestrator) are COPIED to all 6.
 Other skills are symlinked to repo source.
+
+## Claude-native Agents/Skills — COPY exception (Codex→Claude set)
+
+**Why:** the agents symlink resolves through the repo checkout. When that checkout is behind
+the merged `main` (or moved), the symlink silently serves STALE content — which for these
+files means the OLD Codex-dependent version could come back to life. These files are
+correctness-critical: they must ALWAYS be the Claude-native version regardless of repo state.
+A COPY guarantees that. To keep copies from drifting SILENTLY (the inverse failure), a parity
+`--check` makes drift loud.
+
+**Set** (from PR #31's Codex→Claude conversion):
+- Agents (10): `debugger`, `refactorer`, `docs-writer`, `test-architect`, `frontend-reviewer`,
+  `security-auditor`, `ralph-security`, `orchestrator`, `codex-reviewer`, `adversarial-plan-validator`
+- Skills (2): `bugs`, `security`
+
+**Install / refresh the copies:**
+```bash
+bash scripts/install-claude-native-agents.sh
+```
+
+**Verify parity (drift gate — run in CI/local and by validate-global-infrastructure.sh):**
+```bash
+bash scripts/install-claude-native-agents.sh --check
+```
+
+`validate-global-infrastructure.sh` excludes this set from the symlink checks and delegates
+their parity to the installer; its `--fix` RE-SYNCS the copies rather than reverting them to
+symlinks. `codex-cli` / `openai-docs` are out of scope (Codex by nature).
 
 ## Configuration
 

--- a/scripts/install-claude-native-agents.sh
+++ b/scripts/install-claude-native-agents.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# install-claude-native-agents.sh
+#
+# Distribute the Claude-native (Codex-free) review / bug-hunting agents and skills as
+# self-contained COPIES in ~/.claude, NOT symlinks.
+#
+# Why COPY for this specific set (an exception to the "agents are symlinked" default in
+# docs/architecture/DISTRIBUTION_POLICY.md):
+#   The symlinked agents resolve through the repo checkout. When that checkout is behind the
+#   merged main (or moved), the symlink silently serves STALE content — which for these files
+#   means the OLD Codex-dependent version could come back to life. These agents/skills are
+#   correctness-critical: they must ALWAYS be the Claude-native version regardless of repo
+#   state. A copy guarantees that; the --check parity mode below makes copy-drift loud instead
+#   of silent (the same discipline as install-k8s-context-guard.sh).
+#
+# Usage:
+#   bash scripts/install-claude-native-agents.sh          # install/refresh the copies
+#   bash scripts/install-claude-native-agents.sh --check  # verify copies match the repo (CI/local drift gate)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_AGENTS="$HOME/.claude/agents"
+DEST_SKILLS="$HOME/.claude/skills"
+
+# The Codex->Claude conversion set (PR #31). The 7 fully-converted agents, the 3 Codex-optional
+# agents (Claude fallback), and the 2 converted skills.
+AGENTS=(debugger refactorer docs-writer test-architect frontend-reviewer security-auditor \
+        ralph-security orchestrator codex-reviewer adversarial-plan-validator)
+SKILLS=(bugs security)
+
+CHECK=0
+[[ "${1:-}" == "--check" ]] && CHECK=1
+
+total=0; copied=0; drift=0; missing=0
+
+sync_file() {  # sync_file <src> <dest>
+  local src="$1" dest="$2"
+  total=$((total + 1))
+  if [[ ! -f "$src" ]]; then
+    echo "  MISSING SOURCE  $src"; missing=$((missing + 1)); return
+  fi
+  if [[ -f "$dest" && ! -L "$dest" ]] && cmp -s "$src" "$dest"; then
+    [[ $CHECK -eq 1 ]] && echo "  OK      $dest"
+    return
+  fi
+  if [[ $CHECK -eq 1 ]]; then
+    local why="stale copy"; [[ -L "$dest" ]] && why="still a SYMLINK"; [[ ! -e "$dest" ]] && why="absent"
+    echo "  DRIFT   $dest ($why)"; drift=$((drift + 1)); return
+  fi
+  mkdir -p "$(dirname "$dest")"
+  rm -f "$dest"                       # replace a symlink or a stale copy with a fresh one
+  cp "$src" "$dest"
+  echo "  COPIED  $dest"; copied=$((copied + 1))
+}
+
+for a in "${AGENTS[@]}"; do
+  sync_file "$REPO_ROOT/.claude/agents/$a.md" "$DEST_AGENTS/$a.md"
+done
+for s in "${SKILLS[@]}"; do
+  sync_file "$REPO_ROOT/.claude/skills/$s/SKILL.md" "$DEST_SKILLS/$s/SKILL.md"
+done
+
+# Zero-work guard: a run that synced/checked nothing must never report success.
+if [[ $total -eq 0 ]]; then
+  echo "FATAL: no files in the sync set — refusing to report success over an empty run" >&2
+  exit 2
+fi
+
+if [[ $CHECK -eq 1 ]]; then
+  if [[ $drift -eq 0 && $missing -eq 0 ]]; then
+    echo "Parity OK — $total copies match the repo."
+    exit 0
+  fi
+  echo "Parity FAILED — $drift drifted, $missing missing of $total. Fix: bash scripts/install-claude-native-agents.sh" >&2
+  exit 1
+fi
+
+echo "Done. $copied copied, $missing missing source, of $total."
+[[ $missing -gt 0 ]] && exit 1
+exit 0

--- a/scripts/validate-global-infrastructure.sh
+++ b/scripts/validate-global-infrastructure.sh
@@ -153,9 +153,11 @@ for skill in "${SKILLS[@]}"; do
 done
 
 # === 4. KEY AGENTS (must be symlinks) ===
+# NOTE: the Codex->Claude review/bug agents (orchestrator, ralph-security, and the rest of
+# the set) are distributed as COPIES, not symlinks — validated separately in section 4b.
 echo ""
 echo "=== Key Agents (global symlinks) ==="
-AGENTS=(orchestrator ralph-coder ralph-reviewer ralph-tester ralph-researcher ralph-frontend ralph-security autoresearch)
+AGENTS=(ralph-coder ralph-reviewer ralph-tester ralph-researcher ralph-frontend autoresearch)
 for agent in "${AGENTS[@]}"; do
   target=~/.claude/agents/"$agent".md
   if [[ -L "$target" && -f "$target" ]]; then
@@ -184,6 +186,27 @@ for agent in "${AGENTS[@]}"; do
     fi
   fi
 done
+
+# === 4b. CLAUDE-NATIVE COPY AGENTS/SKILLS (Codex->Claude set, COPY not symlink) ===
+# Per docs/architecture/DISTRIBUTION_POLICY.md, the Codex->Claude review/bug agents and the
+# bugs/security skills are COPIES so a stale or moved repo checkout can never resurrect their
+# old Codex-dependent version. Parity (and --fix re-sync) is delegated to their installer, so
+# --fix re-syncs the copies from the repo rather than reverting them to symlinks.
+echo ""
+echo "=== Claude-native COPY agents/skills (parity) ==="
+# Locate the installer relative to THIS script (its sibling in scripts/), not via $REPO —
+# $REPO is a quoted "~/..." literal that does not tilde-expand in this context.
+_cn_installer="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install-claude-native-agents.sh"
+if [[ ! -x "$_cn_installer" && ! -f "$_cn_installer" ]]; then
+  fail "missing $_cn_installer — cannot verify the Claude-native copy set"
+elif bash "$_cn_installer" --check >/dev/null 2>&1; then
+  pass "Claude-native copies match the repo (install-claude-native-agents.sh --check)"
+elif [[ "$FIX_MODE" == "--fix" ]]; then
+  bash "$_cn_installer" >/dev/null 2>&1
+  fixed "Claude-native copies re-synced from repo"
+else
+  fail "Claude-native copies drifted. Fix: bash scripts/install-claude-native-agents.sh"
+fi
 
 # Sweep for ANY broken symlink in ~/.claude/agents (beyond hardcoded list)
 echo ""

--- a/tests/test_claude_native_copies_parity.py
+++ b/tests/test_claude_native_copies_parity.py
@@ -1,0 +1,63 @@
+"""The Codex→Claude agents/skills are distributed as COPIES, and copies must not drift.
+
+PR #31 converted a set of review/bug agents and the bugs/security skills to be Claude-native
+(no hard Codex dependency). They are distributed to ~/.claude as COPIES rather than symlinks so
+a stale or moved repo checkout cannot resurrect their old Codex-dependent version
+(docs/architecture/DISTRIBUTION_POLICY.md). The inverse risk of a copy is SILENT drift, so the
+installer ships a `--check` parity gate — these tests keep it honest.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = REPO_ROOT / "scripts" / "install-claude-native-agents.sh"
+
+EXPECTED_AGENTS = [
+    "debugger", "refactorer", "docs-writer", "test-architect", "frontend-reviewer",
+    "security-auditor", "ralph-security", "orchestrator", "codex-reviewer",
+    "adversarial-plan-validator",
+]
+EXPECTED_SKILLS = ["bugs", "security"]
+
+
+def test_installer_exists_and_is_valid_bash():
+    assert INSTALLER.is_file(), f"missing installer: {INSTALLER}"
+    proc = subprocess.run(["bash", "-n", str(INSTALLER)], capture_output=True, text=True)
+    assert proc.returncode == 0, f"syntax error in installer:\n{proc.stderr}"
+
+
+def test_installer_covers_the_full_conversion_set():
+    """If an agent/skill was converted off Codex, it must be in the copy set — else it stays a
+    symlink and can silently revert to the stale Codex version."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    for name in EXPECTED_AGENTS + EXPECTED_SKILLS:
+        assert name in text, f"{name} missing from the Claude-native copy set in {INSTALLER.name}"
+
+
+def test_installer_has_a_zero_work_guard():
+    """A sync/check that touched nothing must never report success (repo rule)."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "$total -eq 0" in text or "total -eq 0" in text, (
+        "installer lacks a zero-work guard: a run that synced/checked nothing could exit 0"
+    )
+
+
+@pytest.mark.skipif(
+    not (Path.home() / ".claude" / "agents").is_dir(),
+    reason="no local ~/.claude/agents install (expected on CI; parity is a local-install gate)",
+)
+def test_installed_copies_match_the_repo():
+    """`--check` must pass: every installed copy is byte-identical to the repo source."""
+    proc = subprocess.run(
+        ["bash", str(INSTALLER), "--check"], capture_output=True, text=True, timeout=60
+    )
+    output = proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        f"Claude-native copies drifted (or are still symlinks). "
+        f"Fix: bash scripts/install-claude-native-agents.sh\n{output[-1500:]}"
+    )


### PR DESCRIPTION
## Qué

Distribuye el set **Codex→Claude** (agentes de review/bug + skills `bugs`/`security` de PR #31) como **COPIAS self-contained** en `~/.claude`, en vez de symlinks al repo.

## Por qué

Los agentes estaban symlinkeados a `~/.claude/agents → <repo>/.claude/agents`. Cuando el checkout de `main` va detrás del merge —**justo lo que pasó tras mergear #31**— el symlink sirve en silencio la versión **antigua dependiente de Codex**. Estos ficheros son críticos para la corrección: deben ser SIEMPRE la versión Claude-native, sin importar el estado del checkout. Una copia lo garantiza.

Para evitar el fallo inverso (una copia que **deriva en silencio**), se incluye un `--check` de paridad que hace ruidosa la deriva — misma disciplina que `install-k8s-context-guard.sh`.

## Set

- **10 agentes**: `debugger`, `refactorer`, `docs-writer`, `test-architect`, `frontend-reviewer`, `security-auditor`, `ralph-security`, `orchestrator`, `codex-reviewer`, `adversarial-plan-validator`
- **2 skills**: `bugs`, `security`
- Fuera (Codex por naturaleza): `codex-cli`, `openai-docs`

## Cambios

| Fichero | Qué |
|---|---|
| `scripts/install-claude-native-agents.sh` (nuevo) | copia el set repo→`~/.claude` (reemplaza symlinks/copias stale); `--check` verifica paridad byte a byte; guarda de cero-trabajo |
| `scripts/validate-global-infrastructure.sh` | saca `orchestrator`/`ralph-security` de los checks de symlink; añade sección de paridad; su `--fix` **re-sincroniza copias** en vez de revertir a symlink |
| `docs/architecture/DISTRIBUTION_POLICY.md` | documenta la excepción COPY + rationale + comandos |
| `tests/test_claude_native_copies_parity.py` (nuevo) | script válido, cubre el set completo, guarda de cero-trabajo (CI); paridad `--check` pasa con instalación local |

## Nota sobre modelos

Los valores de `model:` ya eran tiers correctos de Claude (opus/sonnet, o herencia intencional del default). **No hizo falta cambiar ningún modelo.**

## Validación

- Runtime ya reinstalado: los 10 agentes vivos son copias, paridad **12/12 OK**, `validate-global-infrastructure.sh` **35/35**.
- `tests/test_claude_native_copies_parity.py`: 4/4. `tests/test_validators_execute_clean.py`: 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
