### PR TITLE
fix(security): remediate confirmed findings from adversarial scan (Plugin 2 Run #7)

### DIFF
--- a/.claude/hooks/git-safety-guard.py
+++ b/.claude/hooks/git-safety-guard.py
@@ -186,33 +186,49 @@ WRAPPER = (
     r"^(?:\w+=\S*\s+)*"  # FOO=bar aws ...
     r"(?:(?:sudo|command|nohup|time|nice|env|eval|xargs)\s+(?:-\S+\s+)*(?:\w+=\S*\s+)*)*"
 )
-# CLI GLOBAL flags sit between the tool name and its subcommand/verb. The destructive
-# patterns anchor `tool\s+<verb>`, so ANY unenumerated global flag in between breaks the
-# adjacency and silently defeats every block (the `gcloud --project=…`, `kubectl -v=6`
-# bypass class found on PR #31). Rather than a fixed allowlist, each prefix now skips a
-# leading run of global flags GENERICALLY: value-taking flags are enumerated (so their
-# value token is consumed too), and every OTHER leading `-`/`--` token is treated as a
-# valueless global and skipped. Subcommands/verbs never start with `-`, so the verb is
-# never swallowed. Only LEADING flags are skipped, so a flag appearing after the verb
-# (`delete … --quiet`, `s3 ls --query "s3 rb"`) stays in the remainder and never widens
-# a match — the anchoring against `echo "aws s3 rb"` (quotes stripped) still holds.
-_GLOBAL_TAIL = r"|--[A-Za-z][\w-]*|-[A-Za-z]+)\s+)*"
-AWS = (
-    WRAPPER + r"aws\s+(?:(?:--(?:profile|region|output|endpoint-url|cli-connect-timeout"
-    r"|cli-read-timeout|color|ca-bundle|query|cli-binary-format)(?:=\S+|\s+\S+)" + _GLOBAL_TAIL
+# CLI GLOBAL flags sit between the tool name and its subcommand/verb.
+# Anti-ReDoS: branches are made mutually exclusive via negative lookahead so
+# that named value-taking flags cannot also match the generic --flag branch.
+# This eliminates exponential backtracking (O(2^N) → O(N)).
+_AWS_VFLAGS = (
+    r"profile|region|output|endpoint-url|cli-connect-timeout"
+    r"|cli-read-timeout|color|ca-bundle|query|cli-binary-format"
 )
-GCLOUD = (
-    WRAPPER + r"gcloud\s+(?:(?:alpha|beta|preview)\s+)?"
-    r"(?:(?:--(?:project|account|configuration|verbosity|format|flags-file|billing-project"
-    r"|impersonate-service-account|access-token-file)(?:=\S+|\s+\S+)" + _GLOBAL_TAIL
+_GCLOUD_VFLAGS = (
+    r"project|account|configuration|verbosity|format|flags-file|billing-project"
+    r"|impersonate-service-account|access-token-file"
 )
-GSUTIL = WRAPPER + r"gsutil\s+(?:-[mqD]\s+)*"
-KUBECTL = (
-    WRAPPER + r"kubectl\s+(?:(?:--(?:context|kubeconfig|namespace|server|token|user|cluster"
+_KUBECTL_VFLAGS = (
+    r"context|kubeconfig|namespace|server|token|user|cluster"
     r"|request-timeout|as|as-group|cache-dir|certificate-authority|client-certificate"
     r"|client-key|tls-server-name|v|log-flush-frequency|chunk-size|password|username"
-    r"|profile|profile-output)(?:=\S+|\s+\S+)|-[nsuvp](?:=\S+|\s+\S+)" + _GLOBAL_TAIL
+    r"|profile|profile-output"
 )
+
+
+def _flag_skip(named_long, named_short=None):
+    """Build a non-backtracking flag-skipping regex group."""
+    b1 = r"--(?:" + named_long + r")(?:=\S+|\s+\S+)"
+    b2 = (r"--(?!(?:" + named_long + r")(?:=|\s|$))"
+          r"[A-Za-z][\w-]*(?:=\S+)?")
+    if named_short:
+        b3 = r"-[" + named_short + r"](?:=\S+|\s+\S+)"
+        b4 = (r"-(?![" + named_short + r"](?:=|\s|$))"
+              r"[A-Za-z]+(?:=\S+)?")
+        inner = r"|".join([b1, b2, b3, b4])
+    else:
+        b3 = r"-[A-Za-z]+(?:=\S+)?"
+        inner = r"|".join([b1, b2, b3])
+    return r"(?:(?:" + inner + r")\s+)*"
+
+
+AWS = WRAPPER + r"aws\s+" + _flag_skip(_AWS_VFLAGS)
+GCLOUD = (
+    WRAPPER + r"gcloud\s+(?:(?:alpha|beta|preview)\s+)?"
+    + _flag_skip(_GCLOUD_VFLAGS)
+)
+GSUTIL = WRAPPER + r"gsutil\s+(?:-[mqD]\s+)*"
+KUBECTL = WRAPPER + r"kubectl\s+" + _flag_skip(_KUBECTL_VFLAGS, "nsuvp")
 
 # Destructive verbs used by the command-substitution / shell -c detectors
 DESTRUCTIVE_INNER = (

--- a/.claude/lib/aaak_cli.py
+++ b/.claude/lib/aaak_cli.py
@@ -35,7 +35,7 @@ from aaak import AAAK  # noqa: E402 -- dynamic path setup above
 def _load_codec(config_path: str = None) -> AAAK:
     """Load codec, optionally with entity config."""
     if config_path:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             cfg = json.load(f)
         return AAAK(
             entities=cfg.get("entities", {}),

--- a/.claude/scripts/ledger-manager.py
+++ b/.claude/scripts/ledger-manager.py
@@ -345,7 +345,7 @@ def main():
         # Load from JSON if provided
         if args.json:
             try:
-                with open(args.json, "r") as f:
+                with open(args.json, "r", encoding="utf-8") as f:
                     data = json.load(f)
             except json.JSONDecodeError as e:
                 print(f"Error: Invalid JSON in {args.json}: {e}", file=sys.stderr)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Validate Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       
       - name: Install dependencies
         run: |
@@ -76,10 +76,10 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
       
@@ -106,7 +106,7 @@ jobs:
     name: Ralph Doctor
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       
       - name: Run ralph-doctor (quick mode)
         run: |

--- a/docs/security/MCP_PLUGINS_ANALYSIS_v2.80.9.md
+++ b/docs/security/MCP_PLUGINS_ANALYSIS_v2.80.9.md
@@ -77,7 +77,7 @@ After rollback issues in `/Users/alfredolopez/.claude-sneakpeek/zai`, there are 
     },
     "context7": {
       "headers": {
-        "CONTEXT7_API_KEY": "ctx7sk-c3b6b82c-0f6c-43c6-8881-2399e202e056"
+        "CONTEXT7_API_KEY": "<REDACTED — rotate at context7.com>"
       },
       "url": "https://mcp.context7.com/mcp"
     }
@@ -225,7 +225,7 @@ bun scripts/worker-service.cjs start
 npx @playwright/mcp@latest --version
 
 # Test context7
-curl -H "CONTEXT7_API_KEY: ctx7sk-c3b6b82c-0f6c-43c6-8881-2399e202e056" \
+curl -H "CONTEXT7_API_KEY: <REDACTED — rotate at context7.com>" \
      https://mcp.context7.com/mcp
 ```
 

--- a/scripts/git-guard.py
+++ b/scripts/git-guard.py
@@ -190,7 +190,7 @@ class GitGuard:
         """
         blocked = []
 
-        with open(script_path, 'r') as f:
+        with open(script_path, 'r', encoding="utf-8") as f:
             content = f.read()
 
         # Split by newlines and check each non-empty line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,7 +260,7 @@ def load_settings_json(settings_json_path):
 
     def _load():
         if os.path.exists(settings_json_path):
-            with open(settings_json_path) as f:
+            with open(settings_json_path, encoding="utf-8") as f:
                 return json.load(f)
         return {}
     return _load
@@ -284,7 +284,7 @@ def validate_skill_frontmatter():
             result["errors"].append(f"File not found: {skill_path}")
             return result
 
-        with open(skill_path) as f:
+        with open(skill_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check for frontmatter

--- a/tests/test_git_safety_guard_restore.py
+++ b/tests/test_git_safety_guard_restore.py
@@ -275,7 +275,7 @@ def test_opaque_relocators_fail_closed(sample_repo, other_repo):
     the file is deleted). `move.sh` is written into other_repo and cds there.
     """
     move = os.path.join(other_repo, "move.sh")
-    with open(move, "w") as fh:
+    with open(move, "w", encoding="utf-8") as fh:
         fh.write(f"cd {other_repo}\n")
     for command in (
         f". {move} ; {RESTORE} deleted.txt",
@@ -382,7 +382,7 @@ def test_eval_dynamic_relocator_fails_closed(sample_repo, other_repo):
     than judged against the payload's cwd where the file happens to be deleted.
     """
     move = os.path.join(other_repo, "move.sh")
-    with open(move, "w") as fh:
+    with open(move, "w", encoding="utf-8") as fh:
         fh.write(f"cd {other_repo}\n")
     assert _decide(f"eval $(cat {move}) ; {RESTORE} deleted.txt", sample_repo) == "deny"
     assert _decide(f'M="cd {other_repo}" ; eval $M ; {RESTORE} deleted.txt', sample_repo) == "deny"

--- a/tests/test_hook_json_format_regression.py
+++ b/tests/test_hook_json_format_regression.py
@@ -94,7 +94,7 @@ def get_hook_type(hook_name: str, settings_json: dict = None) -> str:
     if settings_json is None:
         settings_path = Path.home() / ".claude" / "settings.json"
         if settings_path.exists():
-            with open(settings_path) as f:
+            with open(settings_path, encoding="utf-8") as f:
                 settings_json = json.load(f)
 
     # If settings.json is available, search for actual hook registration
@@ -197,7 +197,7 @@ class TestCriticalFormatRegression:
         settings_path = Path.home() / ".claude" / "settings.json"
         if not settings_path.exists():
             pytest.skip("settings.json not found")
-        with open(settings_path) as f:
+        with open(settings_path, encoding="utf-8") as f:
             return json.load(f)
 
     def test_no_decision_continue_in_any_hook(self, all_hooks):

--- a/tests/test_hooks_registration.py
+++ b/tests/test_hooks_registration.py
@@ -206,7 +206,7 @@ def settings_json(isolated_home):
     settings = {"hooks": hooks_cfg}
     settings_path = isolated_home / ".claude" / "settings.json"
     settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
-    with open(settings_path) as f:
+    with open(settings_path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -308,7 +308,7 @@ class TestHookFilesExist:
         for hook_name in HOOK_REGISTRY.keys():
             hook_path = os.path.join(global_hooks_dir, hook_name)
             if os.path.exists(hook_path):
-                with open(hook_path) as f:
+                with open(hook_path, encoding="utf-8") as f:
                     first_line = f.readline()
                 if not first_line.startswith("#!"):
                     missing_shebang.append(hook_name)
@@ -444,7 +444,7 @@ class TestVersionMarkers:
         for hook_name in HOOK_REGISTRY.keys():
             hook_path = os.path.join(global_hooks_dir, hook_name)
             if os.path.exists(hook_path):
-                with open(hook_path) as f:
+                with open(hook_path, encoding="utf-8") as f:
                     content = f.read()
                 if "VERSION" not in content:
                     missing_version.append(hook_name)

--- a/tests/test_v3_integration.py
+++ b/tests/test_v3_integration.py
@@ -26,7 +26,7 @@ def load_json(path: Path) -> dict:
     """Load JSON file, skip if missing."""
     if not path.exists():
         pytest.skip(f"File not found: {path}")
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/tests/vault/test_karpathi_cycle.py
+++ b/tests/vault/test_karpathi_cycle.py
@@ -92,7 +92,7 @@ def create_minimal_vault(base_dir):
 
     # Create _vault-index.md
     index_path = os.path.join(base_dir, "global", "_vault-index.md")
-    with open(index_path, "w") as f:
+    with open(index_path, "w", encoding="utf-8") as f:
         f.write("## Statistics\n- Total lessons: 5\n- Global wiki articles: 3\n")
 
     return base_dir
@@ -126,7 +126,7 @@ class TestL3VaultQuery:
 
     def test_smart_memory_search_has_l3_section(self):
         """Verify L3 query code was added to smart-memory-search."""
-        with open(os.path.join(HOOKS_DIR, "smart-memory-search.sh")) as f:
+        with open(os.path.join(HOOKS_DIR, "smart-memory-search.sh"), encoding="utf-8") as f:
             content = f.read()
         assert "layers.py" in content
         assert "last-query-hits" in content
@@ -182,7 +182,7 @@ class TestWingCompiler:
             os.makedirs(project_dir, exist_ok=True)
             today = subprocess.check_output(["date", "+%Y%m%d"]).decode().strip()
             facts_file = os.path.join(project_dir, f"facts-{today}.md")
-            with open(facts_file, "w") as f:
+            with open(facts_file, "w", encoding="utf-8") as f:
                 f.write("- [code_structure] Uses async/await pattern in handlers\n")
                 f.write("- [dependencies] Added pytest-cov for coverage\n")
 
@@ -247,7 +247,7 @@ class TestWriteback:
                 "summary": "This is a test summary for writeback.",
                 "category": "hooks",
             }])
-            with open(queue_file, "w") as f:
+            with open(queue_file, "w", encoding="utf-8") as f:
                 f.write(queue_data)
 
             stdin_data = json.dumps({})
@@ -279,7 +279,7 @@ class TestWriteback:
 
             # The draft must carry the writeback frontmatter + summary content.
             article = matches[0]
-            with open(article) as f:
+            with open(article, encoding="utf-8") as f:
                 content = f.read()
             assert "status: draft" in content
             assert "This is a test summary for writeback." in content
@@ -325,7 +325,7 @@ class TestDecisionFilter:
 
     def test_decision_extractor_has_global_filter(self):
         """Verify global decisions filter code was added."""
-        with open(os.path.join(HOOKS_DIR, "decision-extractor.sh")) as f:
+        with open(os.path.join(HOOKS_DIR, "decision-extractor.sh"), encoding="utf-8") as f:
             content = f.read()
         assert "IS_INFRASTRUCTURE" in content
         assert "global/decisions" in content
@@ -412,7 +412,7 @@ class TestVaultLogWriter:
             log_md = os.path.join(vault_dir, "log.md")
             assert os.path.exists(log_md), \
                 "vault-log-writer must create log.md under the vault"
-            with open(log_md) as f:
+            with open(log_md, encoding="utf-8") as f:
                 log_content = f.read()
             assert "test-log-123" in log_content, \
                 "log entry must record the session id"
@@ -445,7 +445,7 @@ class TestHookRegistration:
         settings_path = os.path.expanduser("~/.claude/settings.json")
         if not os.path.exists(settings_path):
             pytest.skip("settings.json not found")
-        with open(settings_path) as f:
+        with open(settings_path, encoding="utf-8") as f:
             return json.load(f)
 
     @pytest.mark.parametrize("hook_name,event", list(EXPECTED_HOOKS.items()))


### PR DESCRIPTION
## Summary

Applies the 4 confirmed fixes from an adversarial analysis of 192 security findings from Plugin 2 Run #7 (28 real / 161 false positives).

## Changes

- **`ci.yml`** — pin `actions/checkout` (v4.4.0) and `actions/setup-python` (v5.6.0) to full commit SHAs — supply-chain hardening (CWE-1357). SHAs resolved via `gh api`.
- **`MCP_PLUGINS_ANALYSIS_v2.80.9.md`** — redact exposed Context7 API key (since rotated by owner).
- **`git-safety-guard.py`** — eliminate ReDoS via negative-lookahead mutual exclusion (O(2^N) backtracking → linear).
- **`encoding="utf-8"`** — add explicit encoding to `open()` calls across `.claude/lib`, `.claude/scripts`, `scripts/`, and `tests/` (`unspecified-open-encoding`).

## Verification

- `py_compile` clean (9 files)
- `ci.yml` valid YAML, 0 unpinned tag refs
- `validate-hooks.sh` — 0 critical
- `pytest tests/test_hooks_*.py` — 168 passed
- Pre-commit validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)